### PR TITLE
Let Completion and Definition return sum types.

### DIFF
--- a/lsp/protocol/generate/tables.go
+++ b/lsp/protocol/generate/tables.go
@@ -7,6 +7,8 @@
 
 package main
 
+import "log"
+
 // prop combines the name of a property with the name of the structure it is in.
 type prop [2]string
 
@@ -22,12 +24,13 @@ const (
 // A.B.C.D means that one of B or C would change to a pointer
 // so a test or initialization would be needed
 var goplsStar = map[prop]int{
+	{"AnnotatedTextEdit", "annotationId"}:  wantOptStar,
 	{"ClientCapabilities", "textDocument"}: wantOpt, // A.B.C.D at fake/editor.go:255
-	{"ClientCapabilities", "window"}:       wantOpt, // regtest failures
-	{"ClientCapabilities", "workspace"}:    wantOpt, // regtest failures
+	{"ClientCapabilities", "window"}:       wantOpt, // test failures
+	{"ClientCapabilities", "workspace"}:    wantOpt, // test failures
 	{"CodeAction", "kind"}:                 wantOpt, // A.B.C.D
 
-	{"CodeActionClientCapabilities", "codeActionLiteralSupport"}: wantOpt, // regtest failures
+	{"CodeActionClientCapabilities", "codeActionLiteralSupport"}: wantOpt, // test failures
 
 	{"CompletionClientCapabilities", "completionItem"}: wantOpt, // A.B.C.D
 	{"CompletionClientCapabilities", "insertTextMode"}: wantOpt, // A.B.C.D
@@ -40,23 +43,16 @@ var goplsStar = map[prop]int{
 	{"Hover", "range"}:                    wantOpt,     // complex expressions
 	{"InlayHint", "kind"}:                 wantOpt,     // temporary variables
 
-	{"Lit_CompletionClientCapabilities_completionItem", "tagSupport"}:     nothing, // A.B.C.
-	{"Lit_SemanticTokensClientCapabilities_requests", "full"}:             nothing, // A.B.C.D
-	{"Lit_SemanticTokensClientCapabilities_requests", "range"}:            nothing, // A.B.C.D
-	{"Lit_SemanticTokensClientCapabilities_requests_full_Item1", "delta"}: nothing, // A.B.C.D
-	{"Lit_SemanticTokensOptions_full_Item1", "delta"}:                     nothing, // A.B.C.
-
-	{"Lit_TextDocumentContentChangeEvent_Item0", "range"}: wantStar, // == nil test
-
-	{"TextDocumentClientCapabilities", "codeAction"}:          wantOpt, // A.B.C.D
-	{"TextDocumentClientCapabilities", "completion"}:          wantOpt, // A.B.C.D
-	{"TextDocumentClientCapabilities", "documentSymbol"}:      wantOpt, // A.B.C.D
-	{"TextDocumentClientCapabilities", "publishDiagnostics"}:  wantOpt, //A.B.C.D
-	{"TextDocumentClientCapabilities", "semanticTokens"}:      wantOpt, // A.B.C.D
-	{"TextDocumentSyncOptions", "change"}:                     wantOpt, // &constant
-	{"WorkDoneProgressParams", "workDoneToken"}:               wantOpt, // regtest
-	{"WorkspaceClientCapabilities", "didChangeConfiguration"}: wantOpt, // A.B.C.D
-	{"WorkspaceClientCapabilities", "didChangeWatchedFiles"}:  wantOpt, // A.B.C.D
+	{"TextDocumentClientCapabilities", "codeAction"}:          wantOpt,     // A.B.C.D
+	{"TextDocumentClientCapabilities", "completion"}:          wantOpt,     // A.B.C.D
+	{"TextDocumentClientCapabilities", "documentSymbol"}:      wantOpt,     // A.B.C.D
+	{"TextDocumentClientCapabilities", "publishDiagnostics"}:  wantOpt,     //A.B.C.D
+	{"TextDocumentClientCapabilities", "semanticTokens"}:      wantOpt,     // A.B.C.D
+	{"TextDocumentContentChangePartial", "range"}:             wantOptStar, // == nil test
+	{"TextDocumentSyncOptions", "change"}:                     wantOpt,     // &constant
+	{"WorkDoneProgressParams", "workDoneToken"}:               wantOpt,     // test failures
+	{"WorkspaceClientCapabilities", "didChangeConfiguration"}: wantOpt,     // A.B.C.D
+	{"WorkspaceClientCapabilities", "didChangeWatchedFiles"}:  wantOpt,     // A.B.C.D
 }
 
 // keep track of which entries in goplsStar are used
@@ -90,7 +86,6 @@ var renameProp = map[prop]string{
 	{"ServerCapabilities", "semanticTokensProvider"}: "interface{}",
 	// slightly tricky
 	{"ServerCapabilities", "textDocumentSync"}: "interface{}",
-	{"TextDocumentEdit", "edits"}:              "[]TextEdit",
 	{"TextDocumentSyncOptions", "save"}:        "SaveOptions",
 	{"WorkspaceEdit", "documentChanges"}:       "[]DocumentChanges",
 }
@@ -111,6 +106,7 @@ var disambiguate = map[string]adjust{
 	"DiagnosticSeverity":           {"Severity", ""},
 	"DocumentDiagnosticReportKind": {"Diagnostic", ""},
 	"FileOperationPatternKind":     {"", "Pattern"},
+	"InlineCompletionTriggerKind":  {"Inline", ""},
 	"InsertTextFormat":             {"", "TextFormat"},
 	"SemanticTokenModifiers":       {"Mod", ""},
 	"SemanticTokenTypes":           {"", "Type"},
@@ -132,103 +128,44 @@ var goplsType = map[string]string{
 	"InitializeParams":                          "ParamInitialize",
 	"LSPAny":                                    "interface{}",
 
-	"Lit_CodeActionClientCapabilities_codeActionLiteralSupport":                "PCodeActionLiteralSupportPCodeAction",
-	"Lit_CodeActionClientCapabilities_codeActionLiteralSupport_codeActionKind": "FCodeActionKindPCodeActionLiteralSupport",
-
-	"Lit_CodeActionClientCapabilities_resolveSupport":     "PResolveSupportPCodeAction",
-	"Lit_CodeAction_disabled":                             "PDisabledMsg_textDocument_codeAction",
-	"Lit_CompletionClientCapabilities_completionItem":     "PCompletionItemPCompletion",
-	"Lit_CompletionClientCapabilities_completionItemKind": "PCompletionItemKindPCompletion",
-
-	"Lit_CompletionClientCapabilities_completionItem_insertTextModeSupport": "FInsertTextModeSupportPCompletionItem",
-
-	"Lit_CompletionClientCapabilities_completionItem_resolveSupport": "FResolveSupportPCompletionItem",
-	"Lit_CompletionClientCapabilities_completionItem_tagSupport":     "FTagSupportPCompletionItem",
-
-	"Lit_CompletionClientCapabilities_completionList":     "PCompletionListPCompletion",
-	"Lit_CompletionList_itemDefaults":                     "PItemDefaultsMsg_textDocument_completion",
-	"Lit_CompletionList_itemDefaults_editRange_Item1":     "FEditRangePItemDefaults",
-	"Lit_CompletionOptions_completionItem":                "PCompletionItemPCompletionProvider",
-	"Lit_DocumentSymbolClientCapabilities_symbolKind":     "PSymbolKindPDocumentSymbol",
-	"Lit_DocumentSymbolClientCapabilities_tagSupport":     "PTagSupportPDocumentSymbol",
-	"Lit_FoldingRangeClientCapabilities_foldingRange":     "PFoldingRangePFoldingRange",
-	"Lit_FoldingRangeClientCapabilities_foldingRangeKind": "PFoldingRangeKindPFoldingRange",
-	"Lit_GeneralClientCapabilities_staleRequestSupport":   "PStaleRequestSupportPGeneral",
-	"Lit_InitializeResult_serverInfo":                     "PServerInfoMsg_initialize",
-	"Lit_InlayHintClientCapabilities_resolveSupport":      "PResolveSupportPInlayHint",
-	"Lit_MarkedString_Item1":                              "Msg_MarkedString",
-	"Lit_NotebookDocumentChangeEvent_cells":               "PCellsPChange",
-	"Lit_NotebookDocumentChangeEvent_cells_structure":     "FStructurePCells",
-	"Lit_NotebookDocumentFilter_Item0":                    "Msg_NotebookDocumentFilter",
-
-	"Lit_NotebookDocumentSyncOptions_notebookSelector_Elem_Item0": "PNotebookSelectorPNotebookDocumentSync",
-
-	"Lit_PrepareRenameResult_Item1": "Msg_PrepareRename2Gn",
-
-	"Lit_PublishDiagnosticsClientCapabilities_tagSupport":       "PTagSupportPPublishDiagnostics",
-	"Lit_SemanticTokensClientCapabilities_requests":             "PRequestsPSemanticTokens",
-	"Lit_SemanticTokensClientCapabilities_requests_full_Item1":  "FFullPRequests",
-	"Lit_SemanticTokensClientCapabilities_requests_range_Item1": "FRangePRequests",
-
-	"Lit_SemanticTokensOptions_full_Item1":  "PFullESemanticTokensOptions",
 	"Lit_SemanticTokensOptions_range_Item1": "PRangeESemanticTokensOptions",
-	"Lit_ServerCapabilities_workspace":      "Workspace6Gn",
 
-	"Lit_ShowMessageRequestClientCapabilities_messageActionItem": "PMessageActionItemPShowMessage",
-	"Lit_SignatureHelpClientCapabilities_signatureInformation":   "PSignatureInformationPSignatureHelp",
-
-	"Lit_SignatureHelpClientCapabilities_signatureInformation_parameterInformation": "FParameterInformationPSignatureInformation",
-
-	"Lit_TextDocumentContentChangeEvent_Item0":                    "Msg_TextDocumentContentChangeEvent",
-	"Lit_TextDocumentFilter_Item0":                                "Msg_TextDocumentFilter",
-	"Lit_TextDocumentFilter_Item1":                                "Msg_TextDocumentFilter",
-	"Lit_WorkspaceEditClientCapabilities_changeAnnotationSupport": "PChangeAnnotationSupportPWorkspaceEdit",
-	"Lit_WorkspaceSymbolClientCapabilities_resolveSupport":        "PResolveSupportPSymbol",
-	"Lit_WorkspaceSymbolClientCapabilities_symbolKind":            "PSymbolKindPSymbol",
-	"Lit_WorkspaceSymbolClientCapabilities_tagSupport":            "PTagSupportPSymbol",
-	"Lit_WorkspaceSymbol_location_Item1":                          "PLocationMsg_workspace_symbol",
-	"Lit__InitializeParams_clientInfo":                            "Msg_XInitializeParams_clientInfo",
-	"Or_CompletionList_itemDefaults_editRange":                    "OrFEditRangePItemDefaults",
 	"Or_Declaration": "[]Location",
 	"Or_DidChangeConfigurationRegistrationOptions_section": "OrPSection_workspace_didChangeConfiguration",
 	"Or_GlobPattern":                "string",
 	"Or_InlayHintLabelPart_tooltip": "OrPTooltipPLabel",
 	"Or_InlayHint_tooltip":          "OrPTooltip_textDocument_inlayHint",
 	"Or_LSPAny":                     "interface{}",
-	"Or_NotebookDocumentFilter":     "Msg_NotebookDocumentFilter",
-	"Or_NotebookDocumentSyncOptions_notebookSelector_Elem": "PNotebookSelectorPNotebookDocumentSync",
 
-	"Or_NotebookDocumentSyncOptions_notebookSelector_Elem_Item0_notebook": "OrFNotebookPNotebookSelector",
+	"Or_ParameterInformation_documentation":            "string",
+	"Or_ParameterInformation_label":                    "string",
+	"Or_PrepareRenameResult":                           "PrepareRenamePlaceholder",
+	"Or_ProgressToken":                                 "interface{}",
+	//"Or_Result_textDocument_completion":                "CompletionList",
+	"Or_Result_textDocument_declaration":               "Or_textDocument_declaration",
+	//"Or_Result_textDocument_definition":                "[]Location",
+	"Or_Result_textDocument_documentSymbol":            "[]interface{}",
+	"Or_Result_textDocument_implementation":            "[]Location",
+	"Or_Result_textDocument_semanticTokens_full_delta": "interface{}",
+	"Or_Result_textDocument_typeDefinition":            "[]Location",
+	"Or_Result_workspace_symbol":                       "[]SymbolInformation",
+	"Or_TextDocumentContentChangeEvent":                "TextDocumentContentChangePartial",
 
-	"Or_ParameterInformation_documentation":                     "string",
-	"Or_ParameterInformation_label":                             "string",
-	"Or_PrepareRenameResult":                                    "Msg_PrepareRename2Gn",
-	"Or_ProgressToken":                                          "interface{}",
-	"Or_Result_textDocument_completion":                         "CompletionList",
-	"Or_Result_textDocument_declaration":                        "Or_textDocument_declaration",
-	"Or_Result_textDocument_definition":                         "[]Location",
-	"Or_Result_textDocument_documentSymbol":                     "[]interface{}",
-	"Or_Result_textDocument_implementation":                     "[]Location",
-	"Or_Result_textDocument_semanticTokens_full_delta":          "interface{}",
-	"Or_Result_textDocument_typeDefinition":                     "[]Location",
-	"Or_Result_workspace_symbol":                                "[]SymbolInformation",
-	"Or_TextDocumentContentChangeEvent":                         "Msg_TextDocumentContentChangeEvent",
-	"Or_TextDocumentFilter":                                     "Msg_TextDocumentFilter",
 	//"Or_WorkspaceFoldersServerCapabilities_changeNotifications": "string",
 	"Or_WorkspaceSymbol_location":                               "OrPLocation_workspace_symbol",
-	"PrepareRenameResult":                                       "PrepareRename2Gn",
-	"Tuple_ParameterInformation_label_Item1":                    "UIntCommaUInt",
-	"WorkspaceFoldersServerCapabilities":                        "WorkspaceFolders5Gn",
-	"[]LSPAny":                                                  "[]interface{}",
-	"[]Or_NotebookDocumentSyncOptions_notebookSelector_Elem":    "[]PNotebookSelectorPNotebookDocumentSync",
-	"[]Or_Result_textDocument_codeAction_Item0_Elem":            "[]CodeAction",
-	"[]PreviousResultId":                                        "[]PreviousResultID",
-	"[]uinteger":                                                "[]uint32",
-	"boolean":                                                   "bool",
-	"decimal":                                                   "float64",
-	"integer":                                                   "int32",
-	"map[DocumentUri][]TextEdit":                                "map[DocumentURI][]TextEdit",
-	"uinteger":                                                  "uint32",
+
+	"Tuple_ParameterInformation_label_Item1": "UIntCommaUInt",
+	"WorkspaceFoldersServerCapabilities":     "WorkspaceFolders5Gn",
+	"[]LSPAny":                               "[]interface{}",
+
+	"[]Or_Result_textDocument_codeAction_Item0_Elem": "[]CodeAction",
+	"[]PreviousResultId":                             "[]PreviousResultID",
+	"[]uinteger":                                     "[]uint32",
+	"boolean":                                        "bool",
+	"decimal":                                        "float64",
+	"integer":                                        "int32",
+	"map[DocumentUri][]TextEdit":                     "map[DocumentURI][]TextEdit",
+	"uinteger":                                       "uint32",
 }
 
 var usedGoplsType = make(map[string]bool)
@@ -277,6 +214,7 @@ var methodNames = map[string]string{
 	"textDocument/hover":                     "Hover",
 	"textDocument/implementation":            "Implementation",
 	"textDocument/inlayHint":                 "InlayHint",
+	"textDocument/inlineCompletion":          "InlineCompletion",
 	"textDocument/inlineValue":               "InlineValue",
 	"textDocument/linkedEditingRange":        "LinkedEditingRange",
 	"textDocument/moniker":                   "Moniker",
@@ -286,6 +224,7 @@ var methodNames = map[string]string{
 	"textDocument/prepareTypeHierarchy":      "PrepareTypeHierarchy",
 	"textDocument/publishDiagnostics":        "PublishDiagnostics",
 	"textDocument/rangeFormatting":           "RangeFormatting",
+	"textDocument/rangesFormatting":          "RangesFormatting",
 	"textDocument/references":                "References",
 	"textDocument/rename":                    "Rename",
 	"textDocument/selectionRange":            "SelectionRange",
@@ -316,6 +255,7 @@ var methodNames = map[string]string{
 	"workspace/didDeleteFiles":               "DidDeleteFiles",
 	"workspace/didRenameFiles":               "DidRenameFiles",
 	"workspace/executeCommand":               "ExecuteCommand",
+	"workspace/foldingRange/refresh":         "FoldingRangeRefresh",
 	"workspace/inlayHint/refresh":            "InlayHintRefresh",
 	"workspace/inlineValue/refresh":          "InlineValueRefresh",
 	"workspace/semanticTokens/refresh":       "SemanticTokensRefresh",
@@ -325,4 +265,12 @@ var methodNames = map[string]string{
 	"workspace/willRenameFiles":              "WillRenameFiles",
 	"workspace/workspaceFolders":             "WorkspaceFolders",
 	"workspaceSymbol/resolve":                "ResolveWorkspaceSymbol",
+}
+
+func methodName(method string) string {
+	ans := methodNames[method]
+	if ans == "" {
+		log.Fatalf("unknown method %q", method)
+	}
+	return ans
 }

--- a/lsp/protocol/tsclient.go
+++ b/lsp/protocol/tsclient.go
@@ -6,8 +6,8 @@
 
 package protocol
 
-// Code generated from protocol/metaModel.json at ref release/protocol/3.17.4-next.0 (hash 5c6ec4f537f304aa1ad645b5fd2bbb757fc40ed1).
-// https://github.com/microsoft/vscode-languageserver-node/blob/release/protocol/3.17.4-next.0/protocol/metaModel.json
+// Code generated from protocol/metaModel.json at ref release/protocol/3.17.6-next.1 (hash d2c907f450cb6d3baff74b31b432b90786d2c3b0).
+// https://github.com/microsoft/vscode-languageserver-node/blob/release/protocol/3.17.6-next.1/protocol/metaModel.json
 // LSP metaData.version = 3.17.0.
 
 import (
@@ -33,6 +33,7 @@ type Client interface {
 	CodeLensRefresh(context.Context) error                                                     // workspace/codeLens/refresh
 	Configuration(context.Context, *ParamConfiguration) ([]LSPAny, error)                      // workspace/configuration
 	DiagnosticRefresh(context.Context) error                                                   // workspace/diagnostic/refresh
+	FoldingRangeRefresh(context.Context) error                                                 // workspace/foldingRange/refresh
 	InlayHintRefresh(context.Context) error                                                    // workspace/inlayHint/refresh
 	InlineValueRefresh(context.Context) error                                                  // workspace/inlineValue/refresh
 	SemanticTokensRefresh(context.Context) error                                               // workspace/semanticTokens/refresh
@@ -150,6 +151,9 @@ func ClientDispatch(ctx context.Context, client Client, conn *jsonrpc2.Conn, r *
 	case "workspace/diagnostic/refresh":
 		err := client.DiagnosticRefresh(ctx)
 		return true, reply(ctx, conn, r, nil, err)
+	case "workspace/foldingRange/refresh":
+		err := client.FoldingRangeRefresh(ctx)
+		return true, reply(ctx, conn, r, nil, err)
 	case "workspace/inlayHint/refresh":
 		err := client.InlayHintRefresh(ctx)
 		return true, reply(ctx, conn, r, nil, err)
@@ -230,6 +234,9 @@ func (s *clientDispatcher) Configuration(ctx context.Context, params *ParamConfi
 }
 func (s *clientDispatcher) DiagnosticRefresh(ctx context.Context) error {
 	return s.sender.Call(ctx, "workspace/diagnostic/refresh", nil, nil)
+}
+func (s *clientDispatcher) FoldingRangeRefresh(ctx context.Context) error {
+	return s.sender.Call(ctx, "workspace/foldingRange/refresh", nil, nil)
 }
 func (s *clientDispatcher) InlayHintRefresh(ctx context.Context) error {
 	return s.sender.Call(ctx, "workspace/inlayHint/refresh", nil, nil)

--- a/lsp/protocol/tsjson.go
+++ b/lsp/protocol/tsjson.go
@@ -6,8 +6,8 @@
 
 package protocol
 
-// Code generated from protocol/metaModel.json at ref release/protocol/3.17.4-next.0 (hash 5c6ec4f537f304aa1ad645b5fd2bbb757fc40ed1).
-// https://github.com/microsoft/vscode-languageserver-node/blob/release/protocol/3.17.4-next.0/protocol/metaModel.json
+// Code generated from protocol/metaModel.json at ref release/protocol/3.17.6-next.1 (hash d2c907f450cb6d3baff74b31b432b90786d2c3b0).
+// https://github.com/microsoft/vscode-languageserver-node/blob/release/protocol/3.17.6-next.1/protocol/metaModel.json
 // LSP metaData.version = 3.17.0.
 
 import "encoding/json"
@@ -23,80 +23,16 @@ type UnmarshalError struct {
 func (e UnmarshalError) Error() string {
 	return e.msg
 }
-
-// from line 4769
-func (t OrFEditRangePItemDefaults) MarshalJSON() ([]byte, error) {
-	switch x := t.Value.(type) {
-	case FEditRangePItemDefaults:
-		return json.Marshal(x)
-	case Range:
-		return json.Marshal(x)
-	case nil:
-		return []byte("null"), nil
-	}
-	return nil, fmt.Errorf("type %T not one of [FEditRangePItemDefaults Range]", t)
-}
-
-func (t *OrFEditRangePItemDefaults) UnmarshalJSON(x []byte) error {
-	if string(x) == "null" {
-		t.Value = nil
-		return nil
-	}
-	var h0 FEditRangePItemDefaults
-	if err := json.Unmarshal(x, &h0); err == nil {
-		t.Value = h0
-		return nil
-	}
-	var h1 Range
-	if err := json.Unmarshal(x, &h1); err == nil {
-		t.Value = h1
-		return nil
-	}
-	return &UnmarshalError{"unmarshal failed to match one of [FEditRangePItemDefaults Range]"}
-}
-
-// from line 9811
-func (t OrFNotebookPNotebookSelector) MarshalJSON() ([]byte, error) {
-	switch x := t.Value.(type) {
-	case NotebookDocumentFilter:
-		return json.Marshal(x)
-	case string:
-		return json.Marshal(x)
-	case nil:
-		return []byte("null"), nil
-	}
-	return nil, fmt.Errorf("type %T not one of [NotebookDocumentFilter string]", t)
-}
-
-func (t *OrFNotebookPNotebookSelector) UnmarshalJSON(x []byte) error {
-	if string(x) == "null" {
-		t.Value = nil
-		return nil
-	}
-	var h0 NotebookDocumentFilter
-	if err := json.Unmarshal(x, &h0); err == nil {
-		t.Value = h0
-		return nil
-	}
-	var h1 string
-	if err := json.Unmarshal(x, &h1); err == nil {
-		t.Value = h1
-		return nil
-	}
-	return &UnmarshalError{"unmarshal failed to match one of [NotebookDocumentFilter string]"}
-}
-
-// from line 5520
 func (t OrPLocation_workspace_symbol) MarshalJSON() ([]byte, error) {
 	switch x := t.Value.(type) {
 	case Location:
 		return json.Marshal(x)
-	case PLocationMsg_workspace_symbol:
+	case LocationUriOnly:
 		return json.Marshal(x)
 	case nil:
 		return []byte("null"), nil
 	}
-	return nil, fmt.Errorf("type %T not one of [Location PLocationMsg_workspace_symbol]", t)
+	return nil, fmt.Errorf("type %T not one of [Location LocationUriOnly]", t)
 }
 
 func (t *OrPLocation_workspace_symbol) UnmarshalJSON(x []byte) error {
@@ -109,15 +45,14 @@ func (t *OrPLocation_workspace_symbol) UnmarshalJSON(x []byte) error {
 		t.Value = h0
 		return nil
 	}
-	var h1 PLocationMsg_workspace_symbol
+	var h1 LocationUriOnly
 	if err := json.Unmarshal(x, &h1); err == nil {
 		t.Value = h1
 		return nil
 	}
-	return &UnmarshalError{"unmarshal failed to match one of [Location PLocationMsg_workspace_symbol]"}
+	return &UnmarshalError{"unmarshal failed to match one of [Location LocationUriOnly]"}
 }
 
-// from line 4163
 func (t OrPSection_workspace_didChangeConfiguration) MarshalJSON() ([]byte, error) {
 	switch x := t.Value.(type) {
 	case []string:
@@ -148,7 +83,6 @@ func (t *OrPSection_workspace_didChangeConfiguration) UnmarshalJSON(x []byte) er
 	return &UnmarshalError{"unmarshal failed to match one of [[]string string]"}
 }
 
-// from line 7075
 func (t OrPTooltipPLabel) MarshalJSON() ([]byte, error) {
 	switch x := t.Value.(type) {
 	case MarkupContent:
@@ -179,7 +113,6 @@ func (t *OrPTooltipPLabel) UnmarshalJSON(x []byte) error {
 	return &UnmarshalError{"unmarshal failed to match one of [MarkupContent string]"}
 }
 
-// from line 3699
 func (t OrPTooltip_textDocument_inlayHint) MarshalJSON() ([]byte, error) {
 	switch x := t.Value.(type) {
 	case MarkupContent:
@@ -210,7 +143,6 @@ func (t *OrPTooltip_textDocument_inlayHint) UnmarshalJSON(x []byte) error {
 	return &UnmarshalError{"unmarshal failed to match one of [MarkupContent string]"}
 }
 
-// from line 6184
 func (t Or_CancelParams_id) MarshalJSON() ([]byte, error) {
 	switch x := t.Value.(type) {
 	case int32:
@@ -241,7 +173,96 @@ func (t *Or_CancelParams_id) UnmarshalJSON(x []byte) error {
 	return &UnmarshalError{"unmarshal failed to match one of [int32 string]"}
 }
 
-// from line 4582
+func (t Or_ClientSemanticTokensRequestOptions_full) MarshalJSON() ([]byte, error) {
+	switch x := t.Value.(type) {
+	case ClientSemanticTokensRequestFullDelta:
+		return json.Marshal(x)
+	case bool:
+		return json.Marshal(x)
+	case nil:
+		return []byte("null"), nil
+	}
+	return nil, fmt.Errorf("type %T not one of [ClientSemanticTokensRequestFullDelta bool]", t)
+}
+
+func (t *Or_ClientSemanticTokensRequestOptions_full) UnmarshalJSON(x []byte) error {
+	if string(x) == "null" {
+		t.Value = nil
+		return nil
+	}
+	var h0 ClientSemanticTokensRequestFullDelta
+	if err := json.Unmarshal(x, &h0); err == nil {
+		t.Value = h0
+		return nil
+	}
+	var h1 bool
+	if err := json.Unmarshal(x, &h1); err == nil {
+		t.Value = h1
+		return nil
+	}
+	return &UnmarshalError{"unmarshal failed to match one of [ClientSemanticTokensRequestFullDelta bool]"}
+}
+
+func (t Or_ClientSemanticTokensRequestOptions_range) MarshalJSON() ([]byte, error) {
+	switch x := t.Value.(type) {
+	case Lit_ClientSemanticTokensRequestOptions_range_Item1:
+		return json.Marshal(x)
+	case bool:
+		return json.Marshal(x)
+	case nil:
+		return []byte("null"), nil
+	}
+	return nil, fmt.Errorf("type %T not one of [Lit_ClientSemanticTokensRequestOptions_range_Item1 bool]", t)
+}
+
+func (t *Or_ClientSemanticTokensRequestOptions_range) UnmarshalJSON(x []byte) error {
+	if string(x) == "null" {
+		t.Value = nil
+		return nil
+	}
+	var h0 Lit_ClientSemanticTokensRequestOptions_range_Item1
+	if err := json.Unmarshal(x, &h0); err == nil {
+		t.Value = h0
+		return nil
+	}
+	var h1 bool
+	if err := json.Unmarshal(x, &h1); err == nil {
+		t.Value = h1
+		return nil
+	}
+	return &UnmarshalError{"unmarshal failed to match one of [Lit_ClientSemanticTokensRequestOptions_range_Item1 bool]"}
+}
+
+func (t Or_CompletionItemDefaults_editRange) MarshalJSON() ([]byte, error) {
+	switch x := t.Value.(type) {
+	case EditRangeWithInsertReplace:
+		return json.Marshal(x)
+	case Range:
+		return json.Marshal(x)
+	case nil:
+		return []byte("null"), nil
+	}
+	return nil, fmt.Errorf("type %T not one of [EditRangeWithInsertReplace Range]", t)
+}
+
+func (t *Or_CompletionItemDefaults_editRange) UnmarshalJSON(x []byte) error {
+	if string(x) == "null" {
+		t.Value = nil
+		return nil
+	}
+	var h0 EditRangeWithInsertReplace
+	if err := json.Unmarshal(x, &h0); err == nil {
+		t.Value = h0
+		return nil
+	}
+	var h1 Range
+	if err := json.Unmarshal(x, &h1); err == nil {
+		t.Value = h1
+		return nil
+	}
+	return &UnmarshalError{"unmarshal failed to match one of [EditRangeWithInsertReplace Range]"}
+}
+
 func (t Or_CompletionItem_documentation) MarshalJSON() ([]byte, error) {
 	switch x := t.Value.(type) {
 	case MarkupContent:
@@ -272,7 +293,6 @@ func (t *Or_CompletionItem_documentation) UnmarshalJSON(x []byte) error {
 	return &UnmarshalError{"unmarshal failed to match one of [MarkupContent string]"}
 }
 
-// from line 4665
 func (t Or_CompletionItem_textEdit) MarshalJSON() ([]byte, error) {
 	switch x := t.Value.(type) {
 	case InsertReplaceEdit:
@@ -303,7 +323,6 @@ func (t *Or_CompletionItem_textEdit) UnmarshalJSON(x []byte) error {
 	return &UnmarshalError{"unmarshal failed to match one of [InsertReplaceEdit TextEdit]"}
 }
 
-// from line 13753
 func (t Or_Definition) MarshalJSON() ([]byte, error) {
 	switch x := t.Value.(type) {
 	case Location:
@@ -334,7 +353,6 @@ func (t *Or_Definition) UnmarshalJSON(x []byte) error {
 	return &UnmarshalError{"unmarshal failed to match one of [Location []Location]"}
 }
 
-// from line 8547
 func (t Or_Diagnostic_code) MarshalJSON() ([]byte, error) {
 	switch x := t.Value.(type) {
 	case int32:
@@ -365,7 +383,6 @@ func (t *Or_Diagnostic_code) UnmarshalJSON(x []byte) error {
 	return &UnmarshalError{"unmarshal failed to match one of [int32 string]"}
 }
 
-// from line 13885
 func (t Or_DocumentDiagnosticReport) MarshalJSON() ([]byte, error) {
 	switch x := t.Value.(type) {
 	case RelatedFullDocumentDiagnosticReport:
@@ -396,7 +413,6 @@ func (t *Or_DocumentDiagnosticReport) UnmarshalJSON(x []byte) error {
 	return &UnmarshalError{"unmarshal failed to match one of [RelatedFullDocumentDiagnosticReport RelatedUnchangedDocumentDiagnosticReport]"}
 }
 
-// from line 3822
 func (t Or_DocumentDiagnosticReportPartialResult_relatedDocuments_Value) MarshalJSON() ([]byte, error) {
 	switch x := t.Value.(type) {
 	case FullDocumentDiagnosticReport:
@@ -427,7 +443,6 @@ func (t *Or_DocumentDiagnosticReportPartialResult_relatedDocuments_Value) Unmars
 	return &UnmarshalError{"unmarshal failed to match one of [FullDocumentDiagnosticReport UnchangedDocumentDiagnosticReport]"}
 }
 
-// from line 14095
 func (t Or_DocumentFilter) MarshalJSON() ([]byte, error) {
 	switch x := t.Value.(type) {
 	case NotebookCellTextDocumentFilter:
@@ -458,7 +473,6 @@ func (t *Or_DocumentFilter) UnmarshalJSON(x []byte) error {
 	return &UnmarshalError{"unmarshal failed to match one of [NotebookCellTextDocumentFilter TextDocumentFilter]"}
 }
 
-// from line 4891
 func (t Or_Hover_contents) MarshalJSON() ([]byte, error) {
 	switch x := t.Value.(type) {
 	case MarkedString:
@@ -496,7 +510,6 @@ func (t *Or_Hover_contents) UnmarshalJSON(x []byte) error {
 	return &UnmarshalError{"unmarshal failed to match one of [MarkedString MarkupContent []MarkedString]"}
 }
 
-// from line 3658
 func (t Or_InlayHint_label) MarshalJSON() ([]byte, error) {
 	switch x := t.Value.(type) {
 	case []InlayHintLabelPart:
@@ -527,7 +540,36 @@ func (t *Or_InlayHint_label) UnmarshalJSON(x []byte) error {
 	return &UnmarshalError{"unmarshal failed to match one of [[]InlayHintLabelPart string]"}
 }
 
-// from line 13863
+func (t Or_InlineCompletionItem_insertText) MarshalJSON() ([]byte, error) {
+	switch x := t.Value.(type) {
+	case StringValue:
+		return json.Marshal(x)
+	case string:
+		return json.Marshal(x)
+	case nil:
+		return []byte("null"), nil
+	}
+	return nil, fmt.Errorf("type %T not one of [StringValue string]", t)
+}
+
+func (t *Or_InlineCompletionItem_insertText) UnmarshalJSON(x []byte) error {
+	if string(x) == "null" {
+		t.Value = nil
+		return nil
+	}
+	var h0 StringValue
+	if err := json.Unmarshal(x, &h0); err == nil {
+		t.Value = h0
+		return nil
+	}
+	var h1 string
+	if err := json.Unmarshal(x, &h1); err == nil {
+		t.Value = h1
+		return nil
+	}
+	return &UnmarshalError{"unmarshal failed to match one of [StringValue string]"}
+}
+
 func (t Or_InlineValue) MarshalJSON() ([]byte, error) {
 	switch x := t.Value.(type) {
 	case InlineValueEvaluatableExpression:
@@ -565,17 +607,16 @@ func (t *Or_InlineValue) UnmarshalJSON(x []byte) error {
 	return &UnmarshalError{"unmarshal failed to match one of [InlineValueEvaluatableExpression InlineValueText InlineValueVariableLookup]"}
 }
 
-// from line 14060
 func (t Or_MarkedString) MarshalJSON() ([]byte, error) {
 	switch x := t.Value.(type) {
-	case Msg_MarkedString:
+	case MarkedStringWithLanguage:
 		return json.Marshal(x)
 	case string:
 		return json.Marshal(x)
 	case nil:
 		return []byte("null"), nil
 	}
-	return nil, fmt.Errorf("type %T not one of [Msg_MarkedString string]", t)
+	return nil, fmt.Errorf("type %T not one of [MarkedStringWithLanguage string]", t)
 }
 
 func (t *Or_MarkedString) UnmarshalJSON(x []byte) error {
@@ -583,7 +624,7 @@ func (t *Or_MarkedString) UnmarshalJSON(x []byte) error {
 		t.Value = nil
 		return nil
 	}
-	var h0 Msg_MarkedString
+	var h0 MarkedStringWithLanguage
 	if err := json.Unmarshal(x, &h0); err == nil {
 		t.Value = h0
 		return nil
@@ -593,10 +634,9 @@ func (t *Or_MarkedString) UnmarshalJSON(x []byte) error {
 		t.Value = h1
 		return nil
 	}
-	return &UnmarshalError{"unmarshal failed to match one of [Msg_MarkedString string]"}
+	return &UnmarshalError{"unmarshal failed to match one of [MarkedStringWithLanguage string]"}
 }
 
-// from line 10118
 func (t Or_NotebookCellTextDocumentFilter_notebook) MarshalJSON() ([]byte, error) {
 	switch x := t.Value.(type) {
 	case NotebookDocumentFilter:
@@ -627,8 +667,44 @@ func (t *Or_NotebookCellTextDocumentFilter_notebook) UnmarshalJSON(x []byte) err
 	return &UnmarshalError{"unmarshal failed to match one of [NotebookDocumentFilter string]"}
 }
 
-// from line 9857
-func (t Or_NotebookDocumentSyncOptions_notebookSelector_Elem_Item1_notebook) MarshalJSON() ([]byte, error) {
+func (t Or_NotebookDocumentFilter) MarshalJSON() ([]byte, error) {
+	switch x := t.Value.(type) {
+	case NotebookDocumentFilterNotebookType:
+		return json.Marshal(x)
+	case NotebookDocumentFilterPattern:
+		return json.Marshal(x)
+	case NotebookDocumentFilterScheme:
+		return json.Marshal(x)
+	case nil:
+		return []byte("null"), nil
+	}
+	return nil, fmt.Errorf("type %T not one of [NotebookDocumentFilterNotebookType NotebookDocumentFilterPattern NotebookDocumentFilterScheme]", t)
+}
+
+func (t *Or_NotebookDocumentFilter) UnmarshalJSON(x []byte) error {
+	if string(x) == "null" {
+		t.Value = nil
+		return nil
+	}
+	var h0 NotebookDocumentFilterNotebookType
+	if err := json.Unmarshal(x, &h0); err == nil {
+		t.Value = h0
+		return nil
+	}
+	var h1 NotebookDocumentFilterPattern
+	if err := json.Unmarshal(x, &h1); err == nil {
+		t.Value = h1
+		return nil
+	}
+	var h2 NotebookDocumentFilterScheme
+	if err := json.Unmarshal(x, &h2); err == nil {
+		t.Value = h2
+		return nil
+	}
+	return &UnmarshalError{"unmarshal failed to match one of [NotebookDocumentFilterNotebookType NotebookDocumentFilterPattern NotebookDocumentFilterScheme]"}
+}
+
+func (t Or_NotebookDocumentFilterWithCells_notebook) MarshalJSON() ([]byte, error) {
 	switch x := t.Value.(type) {
 	case NotebookDocumentFilter:
 		return json.Marshal(x)
@@ -640,7 +716,7 @@ func (t Or_NotebookDocumentSyncOptions_notebookSelector_Elem_Item1_notebook) Mar
 	return nil, fmt.Errorf("type %T not one of [NotebookDocumentFilter string]", t)
 }
 
-func (t *Or_NotebookDocumentSyncOptions_notebookSelector_Elem_Item1_notebook) UnmarshalJSON(x []byte) error {
+func (t *Or_NotebookDocumentFilterWithCells_notebook) UnmarshalJSON(x []byte) error {
 	if string(x) == "null" {
 		t.Value = nil
 		return nil
@@ -658,7 +734,66 @@ func (t *Or_NotebookDocumentSyncOptions_notebookSelector_Elem_Item1_notebook) Un
 	return &UnmarshalError{"unmarshal failed to match one of [NotebookDocumentFilter string]"}
 }
 
-// from line 7168
+func (t Or_NotebookDocumentFilterWithNotebook_notebook) MarshalJSON() ([]byte, error) {
+	switch x := t.Value.(type) {
+	case NotebookDocumentFilter:
+		return json.Marshal(x)
+	case string:
+		return json.Marshal(x)
+	case nil:
+		return []byte("null"), nil
+	}
+	return nil, fmt.Errorf("type %T not one of [NotebookDocumentFilter string]", t)
+}
+
+func (t *Or_NotebookDocumentFilterWithNotebook_notebook) UnmarshalJSON(x []byte) error {
+	if string(x) == "null" {
+		t.Value = nil
+		return nil
+	}
+	var h0 NotebookDocumentFilter
+	if err := json.Unmarshal(x, &h0); err == nil {
+		t.Value = h0
+		return nil
+	}
+	var h1 string
+	if err := json.Unmarshal(x, &h1); err == nil {
+		t.Value = h1
+		return nil
+	}
+	return &UnmarshalError{"unmarshal failed to match one of [NotebookDocumentFilter string]"}
+}
+
+func (t Or_NotebookDocumentSyncOptions_notebookSelector_Elem) MarshalJSON() ([]byte, error) {
+	switch x := t.Value.(type) {
+	case NotebookDocumentFilterWithCells:
+		return json.Marshal(x)
+	case NotebookDocumentFilterWithNotebook:
+		return json.Marshal(x)
+	case nil:
+		return []byte("null"), nil
+	}
+	return nil, fmt.Errorf("type %T not one of [NotebookDocumentFilterWithCells NotebookDocumentFilterWithNotebook]", t)
+}
+
+func (t *Or_NotebookDocumentSyncOptions_notebookSelector_Elem) UnmarshalJSON(x []byte) error {
+	if string(x) == "null" {
+		t.Value = nil
+		return nil
+	}
+	var h0 NotebookDocumentFilterWithCells
+	if err := json.Unmarshal(x, &h0); err == nil {
+		t.Value = h0
+		return nil
+	}
+	var h1 NotebookDocumentFilterWithNotebook
+	if err := json.Unmarshal(x, &h1); err == nil {
+		t.Value = h1
+		return nil
+	}
+	return &UnmarshalError{"unmarshal failed to match one of [NotebookDocumentFilterWithCells NotebookDocumentFilterWithNotebook]"}
+}
+
 func (t Or_RelatedFullDocumentDiagnosticReport_relatedDocuments_Value) MarshalJSON() ([]byte, error) {
 	switch x := t.Value.(type) {
 	case FullDocumentDiagnosticReport:
@@ -689,7 +824,6 @@ func (t *Or_RelatedFullDocumentDiagnosticReport_relatedDocuments_Value) Unmarsha
 	return &UnmarshalError{"unmarshal failed to match one of [FullDocumentDiagnosticReport UnchangedDocumentDiagnosticReport]"}
 }
 
-// from line 7207
 func (t Or_RelatedUnchangedDocumentDiagnosticReport_relatedDocuments_Value) MarshalJSON() ([]byte, error) {
 	switch x := t.Value.(type) {
 	case FullDocumentDiagnosticReport:
@@ -720,7 +854,6 @@ func (t *Or_RelatedUnchangedDocumentDiagnosticReport_relatedDocuments_Value) Unm
 	return &UnmarshalError{"unmarshal failed to match one of [FullDocumentDiagnosticReport UnchangedDocumentDiagnosticReport]"}
 }
 
-// from line 10741
 func (t Or_RelativePattern_baseUri) MarshalJSON() ([]byte, error) {
 	switch x := t.Value.(type) {
 	case URI:
@@ -751,7 +884,6 @@ func (t *Or_RelativePattern_baseUri) UnmarshalJSON(x []byte) error {
 	return &UnmarshalError{"unmarshal failed to match one of [URI WorkspaceFolder]"}
 }
 
-// from line 1371
 func (t Or_Result_textDocument_codeAction_Item0_Elem) MarshalJSON() ([]byte, error) {
 	switch x := t.Value.(type) {
 	case CodeAction:
@@ -782,79 +914,106 @@ func (t *Or_Result_textDocument_codeAction_Item0_Elem) UnmarshalJSON(x []byte) e
 	return &UnmarshalError{"unmarshal failed to match one of [CodeAction Command]"}
 }
 
-// from line 12197
-func (t Or_SemanticTokensClientCapabilities_requests_full) MarshalJSON() ([]byte, error) {
+func (t Or_Result_textDocument_completion) MarshalJSON() ([]byte, error) {
 	switch x := t.Value.(type) {
-	case FFullPRequests:
+	case CompletionList:
 		return json.Marshal(x)
-	case bool:
+	case []CompletionItem:
 		return json.Marshal(x)
 	case nil:
 		return []byte("null"), nil
 	}
-	return nil, fmt.Errorf("type %T not one of [FFullPRequests bool]", t)
+	return nil, fmt.Errorf("type %T not one of [CompletionList []CompletionItem]", t)
 }
 
-func (t *Or_SemanticTokensClientCapabilities_requests_full) UnmarshalJSON(x []byte) error {
+func (t *Or_Result_textDocument_completion) UnmarshalJSON(x []byte) error {
 	if string(x) == "null" {
 		t.Value = nil
 		return nil
 	}
-	var h0 FFullPRequests
+	var h0 CompletionList
 	if err := json.Unmarshal(x, &h0); err == nil {
 		t.Value = h0
 		return nil
 	}
-	var h1 bool
+	var h1 []CompletionItem
 	if err := json.Unmarshal(x, &h1); err == nil {
 		t.Value = h1
 		return nil
 	}
-	return &UnmarshalError{"unmarshal failed to match one of [FFullPRequests bool]"}
+	return &UnmarshalError{"unmarshal failed to match one of [CompletionList []CompletionItem]"}
 }
 
-// from line 12177
-func (t Or_SemanticTokensClientCapabilities_requests_range) MarshalJSON() ([]byte, error) {
+func (t Or_Result_textDocument_definition) MarshalJSON() ([]byte, error) {
 	switch x := t.Value.(type) {
-	case FRangePRequests:
+	case Definition:
 		return json.Marshal(x)
-	case bool:
+	case []DefinitionLink:
 		return json.Marshal(x)
 	case nil:
 		return []byte("null"), nil
 	}
-	return nil, fmt.Errorf("type %T not one of [FRangePRequests bool]", t)
+	return nil, fmt.Errorf("type %T not one of [Definition []DefinitionLink]", t)
 }
 
-func (t *Or_SemanticTokensClientCapabilities_requests_range) UnmarshalJSON(x []byte) error {
+func (t *Or_Result_textDocument_definition) UnmarshalJSON(x []byte) error {
 	if string(x) == "null" {
 		t.Value = nil
 		return nil
 	}
-	var h0 FRangePRequests
+	var h0 Definition
 	if err := json.Unmarshal(x, &h0); err == nil {
 		t.Value = h0
 		return nil
 	}
-	var h1 bool
+	var h1 []DefinitionLink
 	if err := json.Unmarshal(x, &h1); err == nil {
 		t.Value = h1
 		return nil
 	}
-	return &UnmarshalError{"unmarshal failed to match one of [FRangePRequests bool]"}
+	return &UnmarshalError{"unmarshal failed to match one of [Definition []DefinitionLink]"}
 }
 
-// from line 6579
+func (t Or_Result_textDocument_inlineCompletion) MarshalJSON() ([]byte, error) {
+	switch x := t.Value.(type) {
+	case InlineCompletionList:
+		return json.Marshal(x)
+	case []InlineCompletionItem:
+		return json.Marshal(x)
+	case nil:
+		return []byte("null"), nil
+	}
+	return nil, fmt.Errorf("type %T not one of [InlineCompletionList []InlineCompletionItem]", t)
+}
+
+func (t *Or_Result_textDocument_inlineCompletion) UnmarshalJSON(x []byte) error {
+	if string(x) == "null" {
+		t.Value = nil
+		return nil
+	}
+	var h0 InlineCompletionList
+	if err := json.Unmarshal(x, &h0); err == nil {
+		t.Value = h0
+		return nil
+	}
+	var h1 []InlineCompletionItem
+	if err := json.Unmarshal(x, &h1); err == nil {
+		t.Value = h1
+		return nil
+	}
+	return &UnmarshalError{"unmarshal failed to match one of [InlineCompletionList []InlineCompletionItem]"}
+}
+
 func (t Or_SemanticTokensOptions_full) MarshalJSON() ([]byte, error) {
 	switch x := t.Value.(type) {
-	case PFullESemanticTokensOptions:
+	case SemanticTokensFullDelta:
 		return json.Marshal(x)
 	case bool:
 		return json.Marshal(x)
 	case nil:
 		return []byte("null"), nil
 	}
-	return nil, fmt.Errorf("type %T not one of [PFullESemanticTokensOptions bool]", t)
+	return nil, fmt.Errorf("type %T not one of [SemanticTokensFullDelta bool]", t)
 }
 
 func (t *Or_SemanticTokensOptions_full) UnmarshalJSON(x []byte) error {
@@ -862,7 +1021,7 @@ func (t *Or_SemanticTokensOptions_full) UnmarshalJSON(x []byte) error {
 		t.Value = nil
 		return nil
 	}
-	var h0 PFullESemanticTokensOptions
+	var h0 SemanticTokensFullDelta
 	if err := json.Unmarshal(x, &h0); err == nil {
 		t.Value = h0
 		return nil
@@ -872,10 +1031,9 @@ func (t *Or_SemanticTokensOptions_full) UnmarshalJSON(x []byte) error {
 		t.Value = h1
 		return nil
 	}
-	return &UnmarshalError{"unmarshal failed to match one of [PFullESemanticTokensOptions bool]"}
+	return &UnmarshalError{"unmarshal failed to match one of [SemanticTokensFullDelta bool]"}
 }
 
-// from line 6559
 func (t Or_SemanticTokensOptions_range) MarshalJSON() ([]byte, error) {
 	switch x := t.Value.(type) {
 	case PRangeESemanticTokensOptions:
@@ -906,7 +1064,6 @@ func (t *Or_SemanticTokensOptions_range) UnmarshalJSON(x []byte) error {
 	return &UnmarshalError{"unmarshal failed to match one of [PRangeESemanticTokensOptions bool]"}
 }
 
-// from line 8227
 func (t Or_ServerCapabilities_callHierarchyProvider) MarshalJSON() ([]byte, error) {
 	switch x := t.Value.(type) {
 	case CallHierarchyOptions:
@@ -944,7 +1101,6 @@ func (t *Or_ServerCapabilities_callHierarchyProvider) UnmarshalJSON(x []byte) er
 	return &UnmarshalError{"unmarshal failed to match one of [CallHierarchyOptions CallHierarchyRegistrationOptions bool]"}
 }
 
-// from line 8035
 func (t Or_ServerCapabilities_codeActionProvider) MarshalJSON() ([]byte, error) {
 	switch x := t.Value.(type) {
 	case CodeActionOptions:
@@ -975,7 +1131,6 @@ func (t *Or_ServerCapabilities_codeActionProvider) UnmarshalJSON(x []byte) error
 	return &UnmarshalError{"unmarshal failed to match one of [CodeActionOptions bool]"}
 }
 
-// from line 8071
 func (t Or_ServerCapabilities_colorProvider) MarshalJSON() ([]byte, error) {
 	switch x := t.Value.(type) {
 	case DocumentColorOptions:
@@ -1013,7 +1168,6 @@ func (t *Or_ServerCapabilities_colorProvider) UnmarshalJSON(x []byte) error {
 	return &UnmarshalError{"unmarshal failed to match one of [DocumentColorOptions DocumentColorRegistrationOptions bool]"}
 }
 
-// from line 7897
 func (t Or_ServerCapabilities_declarationProvider) MarshalJSON() ([]byte, error) {
 	switch x := t.Value.(type) {
 	case DeclarationOptions:
@@ -1051,7 +1205,6 @@ func (t *Or_ServerCapabilities_declarationProvider) UnmarshalJSON(x []byte) erro
 	return &UnmarshalError{"unmarshal failed to match one of [DeclarationOptions DeclarationRegistrationOptions bool]"}
 }
 
-// from line 7919
 func (t Or_ServerCapabilities_definitionProvider) MarshalJSON() ([]byte, error) {
 	switch x := t.Value.(type) {
 	case DefinitionOptions:
@@ -1082,7 +1235,6 @@ func (t *Or_ServerCapabilities_definitionProvider) UnmarshalJSON(x []byte) error
 	return &UnmarshalError{"unmarshal failed to match one of [DefinitionOptions bool]"}
 }
 
-// from line 8384
 func (t Or_ServerCapabilities_diagnosticProvider) MarshalJSON() ([]byte, error) {
 	switch x := t.Value.(type) {
 	case DiagnosticOptions:
@@ -1113,7 +1265,6 @@ func (t *Or_ServerCapabilities_diagnosticProvider) UnmarshalJSON(x []byte) error
 	return &UnmarshalError{"unmarshal failed to match one of [DiagnosticOptions DiagnosticRegistrationOptions]"}
 }
 
-// from line 8111
 func (t Or_ServerCapabilities_documentFormattingProvider) MarshalJSON() ([]byte, error) {
 	switch x := t.Value.(type) {
 	case DocumentFormattingOptions:
@@ -1144,7 +1295,6 @@ func (t *Or_ServerCapabilities_documentFormattingProvider) UnmarshalJSON(x []byt
 	return &UnmarshalError{"unmarshal failed to match one of [DocumentFormattingOptions bool]"}
 }
 
-// from line 7999
 func (t Or_ServerCapabilities_documentHighlightProvider) MarshalJSON() ([]byte, error) {
 	switch x := t.Value.(type) {
 	case DocumentHighlightOptions:
@@ -1175,7 +1325,6 @@ func (t *Or_ServerCapabilities_documentHighlightProvider) UnmarshalJSON(x []byte
 	return &UnmarshalError{"unmarshal failed to match one of [DocumentHighlightOptions bool]"}
 }
 
-// from line 8129
 func (t Or_ServerCapabilities_documentRangeFormattingProvider) MarshalJSON() ([]byte, error) {
 	switch x := t.Value.(type) {
 	case DocumentRangeFormattingOptions:
@@ -1206,7 +1355,6 @@ func (t *Or_ServerCapabilities_documentRangeFormattingProvider) UnmarshalJSON(x 
 	return &UnmarshalError{"unmarshal failed to match one of [DocumentRangeFormattingOptions bool]"}
 }
 
-// from line 8017
 func (t Or_ServerCapabilities_documentSymbolProvider) MarshalJSON() ([]byte, error) {
 	switch x := t.Value.(type) {
 	case DocumentSymbolOptions:
@@ -1237,7 +1385,6 @@ func (t *Or_ServerCapabilities_documentSymbolProvider) UnmarshalJSON(x []byte) e
 	return &UnmarshalError{"unmarshal failed to match one of [DocumentSymbolOptions bool]"}
 }
 
-// from line 8174
 func (t Or_ServerCapabilities_foldingRangeProvider) MarshalJSON() ([]byte, error) {
 	switch x := t.Value.(type) {
 	case FoldingRangeOptions:
@@ -1275,7 +1422,6 @@ func (t *Or_ServerCapabilities_foldingRangeProvider) UnmarshalJSON(x []byte) err
 	return &UnmarshalError{"unmarshal failed to match one of [FoldingRangeOptions FoldingRangeRegistrationOptions bool]"}
 }
 
-// from line 7870
 func (t Or_ServerCapabilities_hoverProvider) MarshalJSON() ([]byte, error) {
 	switch x := t.Value.(type) {
 	case HoverOptions:
@@ -1306,7 +1452,6 @@ func (t *Or_ServerCapabilities_hoverProvider) UnmarshalJSON(x []byte) error {
 	return &UnmarshalError{"unmarshal failed to match one of [HoverOptions bool]"}
 }
 
-// from line 7959
 func (t Or_ServerCapabilities_implementationProvider) MarshalJSON() ([]byte, error) {
 	switch x := t.Value.(type) {
 	case ImplementationOptions:
@@ -1344,7 +1489,6 @@ func (t *Or_ServerCapabilities_implementationProvider) UnmarshalJSON(x []byte) e
 	return &UnmarshalError{"unmarshal failed to match one of [ImplementationOptions ImplementationRegistrationOptions bool]"}
 }
 
-// from line 8361
 func (t Or_ServerCapabilities_inlayHintProvider) MarshalJSON() ([]byte, error) {
 	switch x := t.Value.(type) {
 	case InlayHintOptions:
@@ -1382,7 +1526,36 @@ func (t *Or_ServerCapabilities_inlayHintProvider) UnmarshalJSON(x []byte) error 
 	return &UnmarshalError{"unmarshal failed to match one of [InlayHintOptions InlayHintRegistrationOptions bool]"}
 }
 
-// from line 8338
+func (t Or_ServerCapabilities_inlineCompletionProvider) MarshalJSON() ([]byte, error) {
+	switch x := t.Value.(type) {
+	case InlineCompletionOptions:
+		return json.Marshal(x)
+	case bool:
+		return json.Marshal(x)
+	case nil:
+		return []byte("null"), nil
+	}
+	return nil, fmt.Errorf("type %T not one of [InlineCompletionOptions bool]", t)
+}
+
+func (t *Or_ServerCapabilities_inlineCompletionProvider) UnmarshalJSON(x []byte) error {
+	if string(x) == "null" {
+		t.Value = nil
+		return nil
+	}
+	var h0 InlineCompletionOptions
+	if err := json.Unmarshal(x, &h0); err == nil {
+		t.Value = h0
+		return nil
+	}
+	var h1 bool
+	if err := json.Unmarshal(x, &h1); err == nil {
+		t.Value = h1
+		return nil
+	}
+	return &UnmarshalError{"unmarshal failed to match one of [InlineCompletionOptions bool]"}
+}
+
 func (t Or_ServerCapabilities_inlineValueProvider) MarshalJSON() ([]byte, error) {
 	switch x := t.Value.(type) {
 	case InlineValueOptions:
@@ -1420,7 +1593,6 @@ func (t *Or_ServerCapabilities_inlineValueProvider) UnmarshalJSON(x []byte) erro
 	return &UnmarshalError{"unmarshal failed to match one of [InlineValueOptions InlineValueRegistrationOptions bool]"}
 }
 
-// from line 8250
 func (t Or_ServerCapabilities_linkedEditingRangeProvider) MarshalJSON() ([]byte, error) {
 	switch x := t.Value.(type) {
 	case LinkedEditingRangeOptions:
@@ -1458,7 +1630,6 @@ func (t *Or_ServerCapabilities_linkedEditingRangeProvider) UnmarshalJSON(x []byt
 	return &UnmarshalError{"unmarshal failed to match one of [LinkedEditingRangeOptions LinkedEditingRangeRegistrationOptions bool]"}
 }
 
-// from line 8292
 func (t Or_ServerCapabilities_monikerProvider) MarshalJSON() ([]byte, error) {
 	switch x := t.Value.(type) {
 	case MonikerOptions:
@@ -1496,7 +1667,6 @@ func (t *Or_ServerCapabilities_monikerProvider) UnmarshalJSON(x []byte) error {
 	return &UnmarshalError{"unmarshal failed to match one of [MonikerOptions MonikerRegistrationOptions bool]"}
 }
 
-// from line 7842
 func (t Or_ServerCapabilities_notebookDocumentSync) MarshalJSON() ([]byte, error) {
 	switch x := t.Value.(type) {
 	case NotebookDocumentSyncOptions:
@@ -1527,7 +1697,6 @@ func (t *Or_ServerCapabilities_notebookDocumentSync) UnmarshalJSON(x []byte) err
 	return &UnmarshalError{"unmarshal failed to match one of [NotebookDocumentSyncOptions NotebookDocumentSyncRegistrationOptions]"}
 }
 
-// from line 7981
 func (t Or_ServerCapabilities_referencesProvider) MarshalJSON() ([]byte, error) {
 	switch x := t.Value.(type) {
 	case ReferenceOptions:
@@ -1558,7 +1727,6 @@ func (t *Or_ServerCapabilities_referencesProvider) UnmarshalJSON(x []byte) error
 	return &UnmarshalError{"unmarshal failed to match one of [ReferenceOptions bool]"}
 }
 
-// from line 8156
 func (t Or_ServerCapabilities_renameProvider) MarshalJSON() ([]byte, error) {
 	switch x := t.Value.(type) {
 	case RenameOptions:
@@ -1589,7 +1757,6 @@ func (t *Or_ServerCapabilities_renameProvider) UnmarshalJSON(x []byte) error {
 	return &UnmarshalError{"unmarshal failed to match one of [RenameOptions bool]"}
 }
 
-// from line 8196
 func (t Or_ServerCapabilities_selectionRangeProvider) MarshalJSON() ([]byte, error) {
 	switch x := t.Value.(type) {
 	case SelectionRangeOptions:
@@ -1627,7 +1794,6 @@ func (t *Or_ServerCapabilities_selectionRangeProvider) UnmarshalJSON(x []byte) e
 	return &UnmarshalError{"unmarshal failed to match one of [SelectionRangeOptions SelectionRangeRegistrationOptions bool]"}
 }
 
-// from line 8273
 func (t Or_ServerCapabilities_semanticTokensProvider) MarshalJSON() ([]byte, error) {
 	switch x := t.Value.(type) {
 	case SemanticTokensOptions:
@@ -1658,7 +1824,6 @@ func (t *Or_ServerCapabilities_semanticTokensProvider) UnmarshalJSON(x []byte) e
 	return &UnmarshalError{"unmarshal failed to match one of [SemanticTokensOptions SemanticTokensRegistrationOptions]"}
 }
 
-// from line 7824
 func (t Or_ServerCapabilities_textDocumentSync) MarshalJSON() ([]byte, error) {
 	switch x := t.Value.(type) {
 	case TextDocumentSyncKind:
@@ -1689,7 +1854,6 @@ func (t *Or_ServerCapabilities_textDocumentSync) UnmarshalJSON(x []byte) error {
 	return &UnmarshalError{"unmarshal failed to match one of [TextDocumentSyncKind TextDocumentSyncOptions]"}
 }
 
-// from line 7937
 func (t Or_ServerCapabilities_typeDefinitionProvider) MarshalJSON() ([]byte, error) {
 	switch x := t.Value.(type) {
 	case TypeDefinitionOptions:
@@ -1727,7 +1891,6 @@ func (t *Or_ServerCapabilities_typeDefinitionProvider) UnmarshalJSON(x []byte) e
 	return &UnmarshalError{"unmarshal failed to match one of [TypeDefinitionOptions TypeDefinitionRegistrationOptions bool]"}
 }
 
-// from line 8315
 func (t Or_ServerCapabilities_typeHierarchyProvider) MarshalJSON() ([]byte, error) {
 	switch x := t.Value.(type) {
 	case TypeHierarchyOptions:
@@ -1765,7 +1928,6 @@ func (t *Or_ServerCapabilities_typeHierarchyProvider) UnmarshalJSON(x []byte) er
 	return &UnmarshalError{"unmarshal failed to match one of [TypeHierarchyOptions TypeHierarchyRegistrationOptions bool]"}
 }
 
-// from line 8093
 func (t Or_ServerCapabilities_workspaceSymbolProvider) MarshalJSON() ([]byte, error) {
 	switch x := t.Value.(type) {
 	case WorkspaceSymbolOptions:
@@ -1796,7 +1958,6 @@ func (t *Or_ServerCapabilities_workspaceSymbolProvider) UnmarshalJSON(x []byte) 
 	return &UnmarshalError{"unmarshal failed to match one of [WorkspaceSymbolOptions bool]"}
 }
 
-// from line 8841
 func (t Or_SignatureInformation_documentation) MarshalJSON() ([]byte, error) {
 	switch x := t.Value.(type) {
 	case MarkupContent:
@@ -1827,7 +1988,6 @@ func (t *Or_SignatureInformation_documentation) UnmarshalJSON(x []byte) error {
 	return &UnmarshalError{"unmarshal failed to match one of [MarkupContent string]"}
 }
 
-// from line 6692
 func (t Or_TextDocumentEdit_edits_Elem) MarshalJSON() ([]byte, error) {
 	switch x := t.Value.(type) {
 	case AnnotatedTextEdit:
@@ -1858,7 +2018,43 @@ func (t *Or_TextDocumentEdit_edits_Elem) UnmarshalJSON(x []byte) error {
 	return &UnmarshalError{"unmarshal failed to match one of [AnnotatedTextEdit TextEdit]"}
 }
 
-// from line 9777
+func (t Or_TextDocumentFilter) MarshalJSON() ([]byte, error) {
+	switch x := t.Value.(type) {
+	case TextDocumentFilterLanguage:
+		return json.Marshal(x)
+	case TextDocumentFilterPattern:
+		return json.Marshal(x)
+	case TextDocumentFilterScheme:
+		return json.Marshal(x)
+	case nil:
+		return []byte("null"), nil
+	}
+	return nil, fmt.Errorf("type %T not one of [TextDocumentFilterLanguage TextDocumentFilterPattern TextDocumentFilterScheme]", t)
+}
+
+func (t *Or_TextDocumentFilter) UnmarshalJSON(x []byte) error {
+	if string(x) == "null" {
+		t.Value = nil
+		return nil
+	}
+	var h0 TextDocumentFilterLanguage
+	if err := json.Unmarshal(x, &h0); err == nil {
+		t.Value = h0
+		return nil
+	}
+	var h1 TextDocumentFilterPattern
+	if err := json.Unmarshal(x, &h1); err == nil {
+		t.Value = h1
+		return nil
+	}
+	var h2 TextDocumentFilterScheme
+	if err := json.Unmarshal(x, &h2); err == nil {
+		t.Value = h2
+		return nil
+	}
+	return &UnmarshalError{"unmarshal failed to match one of [TextDocumentFilterLanguage TextDocumentFilterPattern TextDocumentFilterScheme]"}
+}
+
 func (t Or_TextDocumentSyncOptions_save) MarshalJSON() ([]byte, error) {
 	switch x := t.Value.(type) {
 	case SaveOptions:
@@ -1889,7 +2085,6 @@ func (t *Or_TextDocumentSyncOptions_save) UnmarshalJSON(x []byte) error {
 	return &UnmarshalError{"unmarshal failed to match one of [SaveOptions bool]"}
 }
 
-// from line 13986
 func (t Or_WorkspaceDocumentDiagnosticReport) MarshalJSON() ([]byte, error) {
 	switch x := t.Value.(type) {
 	case WorkspaceFullDocumentDiagnosticReport:
@@ -1920,7 +2115,6 @@ func (t *Or_WorkspaceDocumentDiagnosticReport) UnmarshalJSON(x []byte) error {
 	return &UnmarshalError{"unmarshal failed to match one of [WorkspaceFullDocumentDiagnosticReport WorkspaceUnchangedDocumentDiagnosticReport]"}
 }
 
-// from line 3219
 func (t Or_WorkspaceEdit_documentChanges_Elem) MarshalJSON() ([]byte, error) {
 	switch x := t.Value.(type) {
 	case CreateFile:
@@ -1965,7 +2159,6 @@ func (t *Or_WorkspaceEdit_documentChanges_Elem) UnmarshalJSON(x []byte) error {
 	return &UnmarshalError{"unmarshal failed to match one of [CreateFile DeleteFile RenameFile TextDocumentEdit]"}
 }
 
-// from line 9947
 func (t Or_WorkspaceFoldersServerCapabilities_changeNotifications) MarshalJSON() ([]byte, error) {
 	switch x := t.Value.(type) {
 	case bool:
@@ -1996,7 +2189,6 @@ func (t *Or_WorkspaceFoldersServerCapabilities_changeNotifications) UnmarshalJSO
 	return &UnmarshalError{"unmarshal failed to match one of [bool string]"}
 }
 
-// from line 248
 func (t Or_textDocument_declaration) MarshalJSON() ([]byte, error) {
 	switch x := t.Value.(type) {
 	case Declaration:

--- a/lsp/protocol/tsprotocol.go
+++ b/lsp/protocol/tsprotocol.go
@@ -6,8 +6,8 @@
 
 package protocol
 
-// Code generated from protocol/metaModel.json at ref release/protocol/3.17.4-next.0 (hash 5c6ec4f537f304aa1ad645b5fd2bbb757fc40ed1).
-// https://github.com/microsoft/vscode-languageserver-node/blob/release/protocol/3.17.4-next.0/protocol/metaModel.json
+// Code generated from protocol/metaModel.json at ref release/protocol/3.17.6-next.1 (hash d2c907f450cb6d3baff74b31b432b90786d2c3b0).
+// https://github.com/microsoft/vscode-languageserver-node/blob/release/protocol/3.17.6-next.1/protocol/metaModel.json
 // LSP metaData.version = 3.17.0.
 
 import "encoding/json"
@@ -15,14 +15,14 @@ import "encoding/json"
 // A special text edit with an additional change annotation.
 //
 // @since 3.16.0.
-type AnnotatedTextEdit struct { // line 9372
+type AnnotatedTextEdit struct {
 	// The actual identifier of the change annotation
-	AnnotationID ChangeAnnotationIdentifier `json:"annotationId"`
+	AnnotationID *ChangeAnnotationIdentifier `json:"annotationId,omitempty"`
 	TextEdit
 }
 
-// The parameters passed via a apply workspace edit request.
-type ApplyWorkspaceEditParams struct { // line 5984
+// The parameters passed via an apply workspace edit request.
+type ApplyWorkspaceEditParams struct {
 	// An optional label of the workspace edit. This label is
 	// presented in the user interface for example on an undo
 	// stack to undo the workspace edit.
@@ -34,7 +34,7 @@ type ApplyWorkspaceEditParams struct { // line 5984
 // The result returned from the apply workspace edit request.
 //
 // @since 3.17 renamed from ApplyWorkspaceEditResponse
-type ApplyWorkspaceEditResult struct { // line 6007
+type ApplyWorkspaceEditResult struct {
 	// Indicates whether the edit was applied or not.
 	Applied bool `json:"applied"`
 	// An optional textual description for why the edit was not applied.
@@ -48,7 +48,7 @@ type ApplyWorkspaceEditResult struct { // line 6007
 }
 
 // A base for all symbol information.
-type BaseSymbolInformation struct { // line 8966
+type BaseSymbolInformation struct {
 	// The name of this symbol.
 	Name string `json:"name"`
 	// The kind of this symbol.
@@ -65,7 +65,7 @@ type BaseSymbolInformation struct { // line 8966
 }
 
 // @since 3.16.0
-type CallHierarchyClientCapabilities struct { // line 12141
+type CallHierarchyClientCapabilities struct {
 	// Whether implementation supports dynamic registration. If this is set to `true`
 	// the client supports the new `(TextDocumentRegistrationOptions & StaticRegistrationOptions)`
 	// return value for the corresponding server capability as well.
@@ -75,7 +75,7 @@ type CallHierarchyClientCapabilities struct { // line 12141
 // Represents an incoming call, e.g. a caller of a method or constructor.
 //
 // @since 3.16.0
-type CallHierarchyIncomingCall struct { // line 2779
+type CallHierarchyIncomingCall struct {
 	// The item that makes the call.
 	From CallHierarchyItem `json:"from"`
 	// The ranges at which the calls appear. This is relative to the caller
@@ -86,7 +86,7 @@ type CallHierarchyIncomingCall struct { // line 2779
 // The parameter of a `callHierarchy/incomingCalls` request.
 //
 // @since 3.16.0
-type CallHierarchyIncomingCallsParams struct { // line 2755
+type CallHierarchyIncomingCallsParams struct {
 	Item CallHierarchyItem `json:"item"`
 	WorkDoneProgressParams
 	PartialResultParams
@@ -96,7 +96,7 @@ type CallHierarchyIncomingCallsParams struct { // line 2755
 // of call hierarchy.
 //
 // @since 3.16.0
-type CallHierarchyItem struct { // line 2656
+type CallHierarchyItem struct {
 	// The name of this item.
 	Name string `json:"name"`
 	// The kind of this item.
@@ -120,14 +120,14 @@ type CallHierarchyItem struct { // line 2656
 // Call hierarchy options used during static registration.
 //
 // @since 3.16.0
-type CallHierarchyOptions struct { // line 6534
+type CallHierarchyOptions struct {
 	WorkDoneProgressOptions
 }
 
 // Represents an outgoing call, e.g. calling a getter from a method or a method from a constructor etc.
 //
 // @since 3.16.0
-type CallHierarchyOutgoingCall struct { // line 2829
+type CallHierarchyOutgoingCall struct {
 	// The item that is called.
 	To CallHierarchyItem `json:"to"`
 	// The range at which this item is called. This is the range relative to the caller, e.g the item
@@ -139,7 +139,7 @@ type CallHierarchyOutgoingCall struct { // line 2829
 // The parameter of a `callHierarchy/outgoingCalls` request.
 //
 // @since 3.16.0
-type CallHierarchyOutgoingCallsParams struct { // line 2805
+type CallHierarchyOutgoingCallsParams struct {
 	Item CallHierarchyItem `json:"item"`
 	WorkDoneProgressParams
 	PartialResultParams
@@ -148,7 +148,7 @@ type CallHierarchyOutgoingCallsParams struct { // line 2805
 // The parameter of a `textDocument/prepareCallHierarchy` request.
 //
 // @since 3.16.0
-type CallHierarchyPrepareParams struct { // line 2638
+type CallHierarchyPrepareParams struct {
 	TextDocumentPositionParams
 	WorkDoneProgressParams
 }
@@ -156,12 +156,12 @@ type CallHierarchyPrepareParams struct { // line 2638
 // Call hierarchy options used during static or dynamic registration.
 //
 // @since 3.16.0
-type CallHierarchyRegistrationOptions struct { // line 2733
+type CallHierarchyRegistrationOptions struct {
 	TextDocumentRegistrationOptions
 	CallHierarchyOptions
 	StaticRegistrationOptions
 }
-type CancelParams struct { // line 6179
+type CancelParams struct {
 	// The request id to cancel.
 	ID interface{} `json:"id"`
 }
@@ -169,7 +169,7 @@ type CancelParams struct { // line 6179
 // Additional information that describes document changes.
 //
 // @since 3.16.0
-type ChangeAnnotation struct { // line 6831
+type ChangeAnnotation struct {
 	// A human-readable string describing the actual change. The string
 	// is rendered prominent in the user interface.
 	Label string `json:"label"`
@@ -182,9 +182,18 @@ type ChangeAnnotation struct { // line 6831
 }
 
 // An identifier to refer to a change annotation stored with a workspace edit.
-type ChangeAnnotationIdentifier = string // (alias) line 13976
+type ChangeAnnotationIdentifier = string // (alias)
+// @since 3.18.0
+// @proposed
+type ChangeAnnotationsSupportOptions struct {
+	// Whether the client groups edits with equal labels into tree nodes,
+	// for instance all edits labelled with "Changes in Strings" would
+	// be a tree node.
+	GroupsOnLabel bool `json:"groupsOnLabel,omitempty"`
+}
+
 // Defines the capabilities provided by the client.
-type ClientCapabilities struct { // line 9674
+type ClientCapabilities struct {
 	// Workspace specific client capabilities.
 	Workspace WorkspaceClientCapabilities `json:"workspace,omitempty"`
 	// Text document specific client capabilities.
@@ -203,11 +212,241 @@ type ClientCapabilities struct { // line 9674
 	Experimental interface{} `json:"experimental,omitempty"`
 }
 
+// @since 3.18.0
+// @proposed
+type ClientCodeActionKindOptions struct {
+	// The code action kind values the client supports. When this
+	// property exists the client also guarantees that it will
+	// handle values outside its set gracefully and falls back
+	// to a default value when unknown.
+	ValueSet []CodeActionKind `json:"valueSet"`
+}
+
+// @since 3.18.0
+// @proposed
+type ClientCodeActionLiteralOptions struct {
+	// The code action kind is support with the following value
+	// set.
+	CodeActionKind ClientCodeActionKindOptions `json:"codeActionKind"`
+}
+
+// @since 3.18.0
+// @proposed
+type ClientCodeActionResolveOptions struct {
+	// The properties that a client can resolve lazily.
+	Properties []string `json:"properties"`
+}
+
+// @since 3.18.0
+// @proposed
+type ClientCompletionItemInsertTextModeOptions struct {
+	ValueSet []InsertTextMode `json:"valueSet"`
+}
+
+// @since 3.18.0
+// @proposed
+type ClientCompletionItemOptions struct {
+	// Client supports snippets as insert text.
+	//
+	// A snippet can define tab stops and placeholders with `$1`, `$2`
+	// and `${3:foo}`. `$0` defines the final tab stop, it defaults to
+	// the end of the snippet. Placeholders with equal identifiers are linked,
+	// that is typing in one will update others too.
+	SnippetSupport bool `json:"snippetSupport,omitempty"`
+	// Client supports commit characters on a completion item.
+	CommitCharactersSupport bool `json:"commitCharactersSupport,omitempty"`
+	// Client supports the following content formats for the documentation
+	// property. The order describes the preferred format of the client.
+	DocumentationFormat []MarkupKind `json:"documentationFormat,omitempty"`
+	// Client supports the deprecated property on a completion item.
+	DeprecatedSupport bool `json:"deprecatedSupport,omitempty"`
+	// Client supports the preselect property on a completion item.
+	PreselectSupport bool `json:"preselectSupport,omitempty"`
+	// Client supports the tag property on a completion item. Clients supporting
+	// tags have to handle unknown tags gracefully. Clients especially need to
+	// preserve unknown tags when sending a completion item back to the server in
+	// a resolve call.
+	//
+	// @since 3.15.0
+	TagSupport *CompletionItemTagOptions `json:"tagSupport,omitempty"`
+	// Client support insert replace edit to control different behavior if a
+	// completion item is inserted in the text or should replace text.
+	//
+	// @since 3.16.0
+	InsertReplaceSupport bool `json:"insertReplaceSupport,omitempty"`
+	// Indicates which properties a client can resolve lazily on a completion
+	// item. Before version 3.16.0 only the predefined properties `documentation`
+	// and `details` could be resolved lazily.
+	//
+	// @since 3.16.0
+	ResolveSupport *ClientCompletionItemResolveOptions `json:"resolveSupport,omitempty"`
+	// The client supports the `insertTextMode` property on
+	// a completion item to override the whitespace handling mode
+	// as defined by the client (see `insertTextMode`).
+	//
+	// @since 3.16.0
+	InsertTextModeSupport *ClientCompletionItemInsertTextModeOptions `json:"insertTextModeSupport,omitempty"`
+	// The client has support for completion item label
+	// details (see also `CompletionItemLabelDetails`).
+	//
+	// @since 3.17.0
+	LabelDetailsSupport bool `json:"labelDetailsSupport,omitempty"`
+}
+
+// @since 3.18.0
+// @proposed
+type ClientCompletionItemOptionsKind struct {
+	// The completion item kind values the client supports. When this
+	// property exists the client also guarantees that it will
+	// handle values outside its set gracefully and falls back
+	// to a default value when unknown.
+	//
+	// If this property is not present the client only supports
+	// the completion items kinds from `Text` to `Reference` as defined in
+	// the initial version of the protocol.
+	ValueSet []CompletionItemKind `json:"valueSet,omitempty"`
+}
+
+// @since 3.18.0
+// @proposed
+type ClientCompletionItemResolveOptions struct {
+	// The properties that a client can resolve lazily.
+	Properties []string `json:"properties"`
+}
+
+// @since 3.18.0
+// @proposed
+type ClientDiagnosticsTagOptions struct {
+	// The tags supported by the client.
+	ValueSet []DiagnosticTag `json:"valueSet"`
+}
+
+// @since 3.18.0
+// @proposed
+type ClientFoldingRangeKindOptions struct {
+	// The folding range kind values the client supports. When this
+	// property exists the client also guarantees that it will
+	// handle values outside its set gracefully and falls back
+	// to a default value when unknown.
+	ValueSet []FoldingRangeKind `json:"valueSet,omitempty"`
+}
+
+// @since 3.18.0
+// @proposed
+type ClientFoldingRangeOptions struct {
+	// If set, the client signals that it supports setting collapsedText on
+	// folding ranges to display custom labels instead of the default text.
+	//
+	// @since 3.17.0
+	CollapsedText bool `json:"collapsedText,omitempty"`
+}
+
+// Information about the client
+//
+// @since 3.15.0
+// @since 3.18.0 ClientInfo type name added.
+// @proposed
+type ClientInfo struct {
+	// The name of the client as defined by the client.
+	Name string `json:"name"`
+	// The client's version as defined by the client.
+	Version string `json:"version,omitempty"`
+}
+
+// @since 3.18.0
+// @proposed
+type ClientInlayHintResolveOptions struct {
+	// The properties that a client can resolve lazily.
+	Properties []string `json:"properties"`
+}
+
+// @since 3.18.0
+// @proposed
+type ClientSemanticTokensRequestFullDelta struct {
+	// The client will send the `textDocument/semanticTokens/full/delta` request if
+	// the server provides a corresponding handler.
+	Delta bool `json:"delta,omitempty"`
+}
+
+// @since 3.18.0
+// @proposed
+type ClientSemanticTokensRequestOptions struct {
+	// The client will send the `textDocument/semanticTokens/range` request if
+	// the server provides a corresponding handler.
+	Range *Or_ClientSemanticTokensRequestOptions_range `json:"range,omitempty"`
+	// The client will send the `textDocument/semanticTokens/full` request if
+	// the server provides a corresponding handler.
+	Full *Or_ClientSemanticTokensRequestOptions_full `json:"full,omitempty"`
+}
+
+// @since 3.18.0
+// @proposed
+type ClientShowMessageActionItemOptions struct {
+	// Whether the client supports additional attributes which
+	// are preserved and send back to the server in the
+	// request's response.
+	AdditionalPropertiesSupport bool `json:"additionalPropertiesSupport,omitempty"`
+}
+
+// @since 3.18.0
+// @proposed
+type ClientSignatureInformationOptions struct {
+	// Client supports the following content formats for the documentation
+	// property. The order describes the preferred format of the client.
+	DocumentationFormat []MarkupKind `json:"documentationFormat,omitempty"`
+	// Client capabilities specific to parameter information.
+	ParameterInformation *ClientSignatureParameterInformationOptions `json:"parameterInformation,omitempty"`
+	// The client supports the `activeParameter` property on `SignatureInformation`
+	// literal.
+	//
+	// @since 3.16.0
+	ActiveParameterSupport bool `json:"activeParameterSupport,omitempty"`
+}
+
+// @since 3.18.0
+// @proposed
+type ClientSignatureParameterInformationOptions struct {
+	// The client supports processing label offsets instead of a
+	// simple label string.
+	//
+	// @since 3.14.0
+	LabelOffsetSupport bool `json:"labelOffsetSupport,omitempty"`
+}
+
+// @since 3.18.0
+// @proposed
+type ClientSymbolKindOptions struct {
+	// The symbol kind values the client supports. When this
+	// property exists the client also guarantees that it will
+	// handle values outside its set gracefully and falls back
+	// to a default value when unknown.
+	//
+	// If this property is not present the client only supports
+	// the symbol kinds from `File` to `Array` as defined in
+	// the initial version of the protocol.
+	ValueSet []SymbolKind `json:"valueSet,omitempty"`
+}
+
+// @since 3.18.0
+// @proposed
+type ClientSymbolResolveOptions struct {
+	// The properties that a client can resolve lazily. Usually
+	// `location.range`
+	Properties []string `json:"properties"`
+}
+
+// @since 3.18.0
+// @proposed
+type ClientSymbolTagOptions struct {
+	// The tags supported by the client.
+	ValueSet []SymbolTag `json:"valueSet"`
+}
+
 // A code action represents a change that can be performed in code, e.g. to fix a problem or
 // to refactor code.
 //
 // A CodeAction must set either `edit` and/or a `command`. If both are supplied, the `edit` is applied first, then the `command` is executed.
-type CodeAction struct { // line 5382
+type CodeAction struct {
 	// A short, human-readable, title for this code action.
 	Title string `json:"title"`
 	// The kind of the code action.
@@ -239,7 +478,7 @@ type CodeAction struct { // line 5382
 	//     error message with `reason` in the editor.
 	//
 	// @since 3.16.0
-	Disabled *PDisabledMsg_textDocument_codeAction `json:"disabled,omitempty"`
+	Disabled *CodeActionDisabled `json:"disabled,omitempty"`
 	// The workspace edit this code action performs.
 	Edit *WorkspaceEdit `json:"edit,omitempty"`
 	// A command this code action executes. If a code action
@@ -254,7 +493,7 @@ type CodeAction struct { // line 5382
 }
 
 // The Client Capabilities of a {@link CodeActionRequest}.
-type CodeActionClientCapabilities struct { // line 11721
+type CodeActionClientCapabilities struct {
 	// Whether code action supports dynamic registration.
 	DynamicRegistration bool `json:"dynamicRegistration,omitempty"`
 	// The client support code action literals of type `CodeAction` as a valid
@@ -262,7 +501,7 @@ type CodeActionClientCapabilities struct { // line 11721
 	// set the request can only return `Command` literals.
 	//
 	// @since 3.8.0
-	CodeActionLiteralSupport PCodeActionLiteralSupportPCodeAction `json:"codeActionLiteralSupport,omitempty"`
+	CodeActionLiteralSupport ClientCodeActionLiteralOptions `json:"codeActionLiteralSupport,omitempty"`
 	// Whether code action supports the `isPreferred` property.
 	//
 	// @since 3.15.0
@@ -281,7 +520,7 @@ type CodeActionClientCapabilities struct { // line 11721
 	// properties via a separate `codeAction/resolve` request.
 	//
 	// @since 3.16.0
-	ResolveSupport *PResolveSupportPCodeAction `json:"resolveSupport,omitempty"`
+	ResolveSupport *ClientCodeActionResolveOptions `json:"resolveSupport,omitempty"`
 	// Whether the client honors the change annotations in
 	// text edits and resource operations returned via the
 	// `CodeAction#edit` property by for example presenting
@@ -294,7 +533,7 @@ type CodeActionClientCapabilities struct { // line 11721
 
 // Contains additional diagnostic information about the context in which
 // a {@link CodeActionProvider.provideCodeActions code action} is run.
-type CodeActionContext struct { // line 9032
+type CodeActionContext struct {
 	// An array of diagnostics known on the client side overlapping the range provided to the
 	// `textDocument/codeAction` request. They are provided so that the server knows which
 	// errors are currently presented to the user for the given range. There is no guarantee
@@ -312,10 +551,22 @@ type CodeActionContext struct { // line 9032
 	TriggerKind *CodeActionTriggerKind `json:"triggerKind,omitempty"`
 }
 
+// Captures why the code action is currently disabled.
+//
+// @since 3.18.0
+// @proposed
+type CodeActionDisabled struct {
+	// Human readable description of why the code action is currently disabled.
+	//
+	// This is displayed in the code actions UI.
+	Reason string `json:"reason"`
+}
+
 // A set of predefined code action kinds
-type CodeActionKind string // line 13326
+type CodeActionKind string
+
 // Provider options for a {@link CodeActionRequest}.
-type CodeActionOptions struct { // line 9071
+type CodeActionOptions struct {
 	// CodeActionKinds that this server may return.
 	//
 	// The list of kinds may be generic, such as `CodeActionKind.Refactor`, or the server
@@ -330,7 +581,7 @@ type CodeActionOptions struct { // line 9071
 }
 
 // The parameters of a {@link CodeActionRequest}.
-type CodeActionParams struct { // line 5308
+type CodeActionParams struct {
 	// The document in which the command was invoked.
 	TextDocument TextDocumentIdentifier `json:"textDocument"`
 	// The range for which the command was invoked.
@@ -342,7 +593,7 @@ type CodeActionParams struct { // line 5308
 }
 
 // Registration options for a {@link CodeActionRequest}.
-type CodeActionRegistrationOptions struct { // line 5476
+type CodeActionRegistrationOptions struct {
 	TextDocumentRegistrationOptions
 	CodeActionOptions
 }
@@ -350,11 +601,12 @@ type CodeActionRegistrationOptions struct { // line 5476
 // The reason why code actions were requested.
 //
 // @since 3.17.0
-type CodeActionTriggerKind uint32 // line 13606
+type CodeActionTriggerKind uint32
+
 // Structure to capture a description for an error code.
 //
 // @since 3.16.0
-type CodeDescription struct { // line 10026
+type CodeDescription struct {
 	// An URI to open with more information about the diagnostic error.
 	Href URI `json:"href"`
 }
@@ -364,32 +616,31 @@ type CodeDescription struct { // line 10026
 //
 // A code lens is _unresolved_ when no command is associated to it. For performance
 // reasons the creation of a code lens and resolving should be done in two stages.
-type CodeLens struct { // line 5599
+type CodeLens struct {
 	// The range in which this code lens is valid. Should only span a single line.
 	Range Range `json:"range"`
 	// The command this code lens represents.
 	Command *Command `json:"command,omitempty"`
 	// A data entry field that is preserved on a code lens item between
-	// a {@link CodeLensRequest} and a [CodeLensResolveRequest]
-	// (#CodeLensResolveRequest)
+	// a {@link CodeLensRequest} and a {@link CodeLensResolveRequest}
 	Data interface{} `json:"data,omitempty"`
 }
 
 // The client capabilities  of a {@link CodeLensRequest}.
-type CodeLensClientCapabilities struct { // line 11835
+type CodeLensClientCapabilities struct {
 	// Whether code lens supports dynamic registration.
 	DynamicRegistration bool `json:"dynamicRegistration,omitempty"`
 }
 
 // Code Lens provider options of a {@link CodeLensRequest}.
-type CodeLensOptions struct { // line 9127
+type CodeLensOptions struct {
 	// Code lens has a resolve provider as well.
 	ResolveProvider bool `json:"resolveProvider,omitempty"`
 	WorkDoneProgressOptions
 }
 
 // The parameters of a {@link CodeLensRequest}.
-type CodeLensParams struct { // line 5575
+type CodeLensParams struct {
 	// The document to request code lens for.
 	TextDocument TextDocumentIdentifier `json:"textDocument"`
 	WorkDoneProgressParams
@@ -397,13 +648,13 @@ type CodeLensParams struct { // line 5575
 }
 
 // Registration options for a {@link CodeLensRequest}.
-type CodeLensRegistrationOptions struct { // line 5631
+type CodeLensRegistrationOptions struct {
 	TextDocumentRegistrationOptions
 	CodeLensOptions
 }
 
 // @since 3.16.0
-type CodeLensWorkspaceClientCapabilities struct { // line 10993
+type CodeLensWorkspaceClientCapabilities struct {
 	// Whether the client implementation supports a refresh request sent from the
 	// server to the client.
 	//
@@ -415,7 +666,7 @@ type CodeLensWorkspaceClientCapabilities struct { // line 10993
 }
 
 // Represents a color in RGBA space.
-type Color struct { // line 6433
+type Color struct {
 	// The red component of this color in the range [0-1].
 	Red float64 `json:"red"`
 	// The green component of this color in the range [0-1].
@@ -427,13 +678,13 @@ type Color struct { // line 6433
 }
 
 // Represents a color range from a document.
-type ColorInformation struct { // line 2239
+type ColorInformation struct {
 	// The range in the document where this color appears.
 	Range Range `json:"range"`
 	// The actual color value for this color range.
 	Color Color `json:"color"`
 }
-type ColorPresentation struct { // line 2321
+type ColorPresentation struct {
 	// The label of this color presentation. It will be shown on the color
 	// picker header. By default this is also the text that is inserted when selecting
 	// this color presentation.
@@ -448,7 +699,7 @@ type ColorPresentation struct { // line 2321
 }
 
 // Parameters for a {@link ColorPresentationRequest}.
-type ColorPresentationParams struct { // line 2281
+type ColorPresentationParams struct {
 	// The text document.
 	TextDocument TextDocumentIdentifier `json:"textDocument"`
 	// The color to request presentations for.
@@ -463,7 +714,7 @@ type ColorPresentationParams struct { // line 2281
 // will be used to represent a command in the UI and, optionally,
 // an array of arguments which will be passed to the command handler
 // function when invoked.
-type Command struct { // line 5348
+type Command struct {
 	// Title of the command, like `save`.
 	Title string `json:"title"`
 	// The identifier of the actual command handler.
@@ -474,13 +725,13 @@ type Command struct { // line 5348
 }
 
 // Completion client capabilities
-type CompletionClientCapabilities struct { // line 11168
+type CompletionClientCapabilities struct {
 	// Whether completion supports dynamic registration.
 	DynamicRegistration bool `json:"dynamicRegistration,omitempty"`
 	// The client supports the following `CompletionItem` specific
 	// capabilities.
-	CompletionItem     PCompletionItemPCompletion      `json:"completionItem,omitempty"`
-	CompletionItemKind *PCompletionItemKindPCompletion `json:"completionItemKind,omitempty"`
+	CompletionItem     ClientCompletionItemOptions      `json:"completionItem,omitempty"`
+	CompletionItemKind *ClientCompletionItemOptionsKind `json:"completionItemKind,omitempty"`
 	// Defines how the client handles whitespace and indentation
 	// when accepting a completion item that uses multi line
 	// text in either `insertText` or `textEdit`.
@@ -494,11 +745,11 @@ type CompletionClientCapabilities struct { // line 11168
 	// capabilities.
 	//
 	// @since 3.17.0
-	CompletionList *PCompletionListPCompletion `json:"completionList,omitempty"`
+	CompletionList *CompletionListCapabilities `json:"completionList,omitempty"`
 }
 
 // Contains additional information about the context in which a completion request is triggered.
-type CompletionContext struct { // line 8628
+type CompletionContext struct {
 	// How the completion was triggered.
 	TriggerKind CompletionTriggerKind `json:"triggerKind"`
 	// The trigger character (a single character) that has trigger code complete.
@@ -508,7 +759,7 @@ type CompletionContext struct { // line 8628
 
 // A completion item represents a text snippet that is
 // proposed to complete text that is being typed.
-type CompletionItem struct { // line 4528
+type CompletionItem struct {
 	// The label of this completion item.
 	//
 	// The label property is also by default the text that
@@ -628,12 +879,49 @@ type CompletionItem struct { // line 4528
 	Data interface{} `json:"data,omitempty"`
 }
 
+// In many cases the items of an actual completion result share the same
+// value for properties like `commitCharacters` or the range of a text
+// edit. A completion list can therefore define item defaults which will
+// be used if a completion item itself doesn't specify the value.
+//
+// If a completion list specifies a default value and a completion item
+// also specifies a corresponding value the one from the item is used.
+//
+// Servers are only allowed to return default values if the client
+// signals support for this via the `completionList.itemDefaults`
+// capability.
+//
+// @since 3.17.0
+type CompletionItemDefaults struct {
+	// A default commit character set.
+	//
+	// @since 3.17.0
+	CommitCharacters []string `json:"commitCharacters,omitempty"`
+	// A default edit range.
+	//
+	// @since 3.17.0
+	EditRange *Or_CompletionItemDefaults_editRange `json:"editRange,omitempty"`
+	// A default insert text format.
+	//
+	// @since 3.17.0
+	InsertTextFormat *InsertTextFormat `json:"insertTextFormat,omitempty"`
+	// A default insert text mode.
+	//
+	// @since 3.17.0
+	InsertTextMode *InsertTextMode `json:"insertTextMode,omitempty"`
+	// A default data value.
+	//
+	// @since 3.17.0
+	Data interface{} `json:"data,omitempty"`
+}
+
 // The kind of a completion entry.
-type CompletionItemKind uint32 // line 13134
+type CompletionItemKind uint32
+
 // Additional details for a completion item label.
 //
 // @since 3.17.0
-type CompletionItemLabelDetails struct { // line 8651
+type CompletionItemLabelDetails struct {
 	// An optional string which is rendered less prominently directly after {@link CompletionItem.label label},
 	// without any spacing. Should be used for function signatures and type annotations.
 	Detail string `json:"detail,omitempty"`
@@ -646,10 +934,18 @@ type CompletionItemLabelDetails struct { // line 8651
 // item.
 //
 // @since 3.15.0
-type CompletionItemTag uint32 // line 13244
+type CompletionItemTag uint32
+
+// @since 3.18.0
+// @proposed
+type CompletionItemTagOptions struct {
+	// The tags supported by the client.
+	ValueSet []CompletionItemTag `json:"valueSet"`
+}
+
 // Represents a collection of {@link CompletionItem completion items} to be presented
 // in the editor.
-type CompletionList struct { // line 4737
+type CompletionList struct {
 	// This list it not complete. Further typing results in recomputing this list.
 	//
 	// Recomputed lists have all their items replaced (not appended) in the
@@ -668,13 +964,29 @@ type CompletionList struct { // line 4737
 	// capability.
 	//
 	// @since 3.17.0
-	ItemDefaults *PItemDefaultsMsg_textDocument_completion `json:"itemDefaults,omitempty"`
+	ItemDefaults *CompletionItemDefaults `json:"itemDefaults,omitempty"`
 	// The completion items.
 	Items []CompletionItem `json:"items"`
 }
 
+// The client supports the following `CompletionList` specific
+// capabilities.
+//
+// @since 3.17.0
+type CompletionListCapabilities struct {
+	// The client supports the following itemDefaults on
+	// a completion list.
+	//
+	// The value lists the supported property names of the
+	// `CompletionList.itemDefaults` object. If omitted
+	// no properties are supported.
+	//
+	// @since 3.17.0
+	ItemDefaults []string `json:"itemDefaults,omitempty"`
+}
+
 // Completion options.
-type CompletionOptions struct { // line 8707
+type CompletionOptions struct {
 	// Most tools trigger completion request automatically without explicitly requesting
 	// it using a keyboard shortcut (e.g. Ctrl+Space). Typically they do so when the user
 	// starts to type an identifier. For example if the user types `c` in a JavaScript file
@@ -700,12 +1012,12 @@ type CompletionOptions struct { // line 8707
 	// capabilities.
 	//
 	// @since 3.17.0
-	CompletionItem *PCompletionItemPCompletionProvider `json:"completionItem,omitempty"`
+	CompletionItem *ServerCompletionItemOptions `json:"completionItem,omitempty"`
 	WorkDoneProgressOptions
 }
 
 // Completion parameters
-type CompletionParams struct { // line 4497
+type CompletionParams struct {
 	// The completion context. This is only available it the client specifies
 	// to send this using the client capability `textDocument.completion.contextSupport === true`
 	Context CompletionContext `json:"context,omitempty"`
@@ -715,27 +1027,27 @@ type CompletionParams struct { // line 4497
 }
 
 // Registration options for a {@link CompletionRequest}.
-type CompletionRegistrationOptions struct { // line 4854
+type CompletionRegistrationOptions struct {
 	TextDocumentRegistrationOptions
 	CompletionOptions
 }
 
 // How a completion was triggered
-type CompletionTriggerKind uint32 // line 13555
-type ConfigurationItem struct {   // line 6396
+type CompletionTriggerKind uint32
+type ConfigurationItem struct {
 	// The scope to get the configuration section for.
-	ScopeURI string `json:"scopeUri,omitempty"`
+	ScopeURI *URI `json:"scopeUri,omitempty"`
 	// The configuration section asked for.
 	Section string `json:"section,omitempty"`
 }
 
 // The parameters of a configuration request.
-type ConfigurationParams struct { // line 2199
+type ConfigurationParams struct {
 	Items []ConfigurationItem `json:"items"`
 }
 
 // Create file operation.
-type CreateFile struct { // line 6712
+type CreateFile struct {
 	// A create
 	Kind string `json:"kind"`
 	// The resource to create.
@@ -746,7 +1058,7 @@ type CreateFile struct { // line 6712
 }
 
 // Options to create a file.
-type CreateFileOptions struct { // line 9417
+type CreateFileOptions struct {
 	// Overwrite existing file. Overwrite wins over `ignoreIfExists`
 	Overwrite bool `json:"overwrite,omitempty"`
 	// Ignore if exists.
@@ -757,15 +1069,15 @@ type CreateFileOptions struct { // line 9417
 // files.
 //
 // @since 3.16.0
-type CreateFilesParams struct { // line 3175
+type CreateFilesParams struct {
 	// An array of all files/folders created in this operation.
 	Files []FileCreate `json:"files"`
 }
 
 // The declaration of a symbol representation as one or many {@link Location locations}.
-type Declaration = []Location // (alias) line 13833
+type Declaration = []Location // (alias)
 // @since 3.14.0
-type DeclarationClientCapabilities struct { // line 11509
+type DeclarationClientCapabilities struct {
 	// Whether declaration supports dynamic registration. If this is set to `true`
 	// the client supports the new `DeclarationRegistrationOptions` return value
 	// for the corresponding server capability as well.
@@ -781,16 +1093,16 @@ type DeclarationClientCapabilities struct { // line 11509
 //
 // Servers should prefer returning `DeclarationLink` over `Declaration` if supported
 // by the client.
-type DeclarationLink = LocationLink // (alias) line 13853
-type DeclarationOptions struct {    // line 6491
+type DeclarationLink = LocationLink // (alias)
+type DeclarationOptions struct {
 	WorkDoneProgressOptions
 }
-type DeclarationParams struct { // line 2494
+type DeclarationParams struct {
 	TextDocumentPositionParams
 	WorkDoneProgressParams
 	PartialResultParams
 }
-type DeclarationRegistrationOptions struct { // line 2514
+type DeclarationRegistrationOptions struct {
 	DeclarationOptions
 	TextDocumentRegistrationOptions
 	StaticRegistrationOptions
@@ -802,9 +1114,9 @@ type DeclarationRegistrationOptions struct { // line 2514
 //
 // Servers should prefer returning `DefinitionLink` over `Definition` if supported
 // by the client.
-type Definition = Or_Definition // (alias) line 13751
+type Definition = Or_Definition // (alias)
 // Client Capabilities for a {@link DefinitionRequest}.
-type DefinitionClientCapabilities struct { // line 11534
+type DefinitionClientCapabilities struct {
 	// Whether definition supports dynamic registration.
 	DynamicRegistration bool `json:"dynamicRegistration,omitempty"`
 	// The client supports additional metadata in the form of definition links.
@@ -817,27 +1129,27 @@ type DefinitionClientCapabilities struct { // line 11534
 //
 // Provides additional metadata over normal {@link Location location} definitions, including the range of
 // the defining symbol
-type DefinitionLink = LocationLink // (alias) line 13771
+type DefinitionLink = LocationLink // (alias)
 // Server Capabilities for a {@link DefinitionRequest}.
-type DefinitionOptions struct { // line 8919
+type DefinitionOptions struct {
 	WorkDoneProgressOptions
 }
 
 // Parameters for a {@link DefinitionRequest}.
-type DefinitionParams struct { // line 5018
+type DefinitionParams struct {
 	TextDocumentPositionParams
 	WorkDoneProgressParams
 	PartialResultParams
 }
 
 // Registration options for a {@link DefinitionRequest}.
-type DefinitionRegistrationOptions struct { // line 5039
+type DefinitionRegistrationOptions struct {
 	TextDocumentRegistrationOptions
 	DefinitionOptions
 }
 
 // Delete file operation
-type DeleteFile struct { // line 6794
+type DeleteFile struct {
 	// A delete
 	Kind string `json:"kind"`
 	// The file to delete.
@@ -848,7 +1160,7 @@ type DeleteFile struct { // line 6794
 }
 
 // Delete file options
-type DeleteFileOptions struct { // line 9465
+type DeleteFileOptions struct {
 	// Delete the content recursively if a folder is denoted.
 	Recursive bool `json:"recursive,omitempty"`
 	// Ignore the operation if the file doesn't exist.
@@ -859,14 +1171,14 @@ type DeleteFileOptions struct { // line 9465
 // files.
 //
 // @since 3.16.0
-type DeleteFilesParams struct { // line 3300
+type DeleteFilesParams struct {
 	// An array of all files/folders deleted in this operation.
 	Files []FileDelete `json:"files"`
 }
 
 // Represents a diagnostic, such as a compiler error or warning. Diagnostic objects
 // are only valid in the scope of a resource.
-type Diagnostic struct { // line 8525
+type Diagnostic struct {
 	// The range at which the message applies
 	Range Range `json:"range"`
 	// The diagnostic's severity. Can be omitted. If omitted it is up to the
@@ -902,7 +1214,7 @@ type Diagnostic struct { // line 8525
 // Client capabilities specific to diagnostic pull requests.
 //
 // @since 3.17.0
-type DiagnosticClientCapabilities struct { // line 12408
+type DiagnosticClientCapabilities struct {
 	// Whether implementation supports dynamic registration. If this is set to `true`
 	// the client supports the new `(TextDocumentRegistrationOptions & StaticRegistrationOptions)`
 	// return value for the corresponding server capability as well.
@@ -914,7 +1226,7 @@ type DiagnosticClientCapabilities struct { // line 12408
 // Diagnostic options.
 //
 // @since 3.17.0
-type DiagnosticOptions struct { // line 7293
+type DiagnosticOptions struct {
 	// An optional identifier under which the diagnostics are
 	// managed by the client.
 	Identifier string `json:"identifier,omitempty"`
@@ -931,7 +1243,7 @@ type DiagnosticOptions struct { // line 7293
 // Diagnostic registration options.
 //
 // @since 3.17.0
-type DiagnosticRegistrationOptions struct { // line 3855
+type DiagnosticRegistrationOptions struct {
 	TextDocumentRegistrationOptions
 	DiagnosticOptions
 	StaticRegistrationOptions
@@ -940,7 +1252,7 @@ type DiagnosticRegistrationOptions struct { // line 3855
 // Represents a related message and source code location for a diagnostic. This should be
 // used to point to code locations that cause or related to a diagnostics, e.g when duplicating
 // a symbol in a scope.
-type DiagnosticRelatedInformation struct { // line 10041
+type DiagnosticRelatedInformation struct {
 	// The location of this related diagnostic information.
 	Location Location `json:"location"`
 	// The message of this related diagnostic information.
@@ -950,20 +1262,22 @@ type DiagnosticRelatedInformation struct { // line 10041
 // Cancellation data returned from a diagnostic request.
 //
 // @since 3.17.0
-type DiagnosticServerCancellationData struct { // line 3841
+type DiagnosticServerCancellationData struct {
 	RetriggerRequest bool `json:"retriggerRequest"`
 }
 
 // The diagnostic's severity.
-type DiagnosticSeverity uint32 // line 13504
+type DiagnosticSeverity uint32
+
 // The diagnostic tags.
 //
 // @since 3.15.0
-type DiagnosticTag uint32 // line 13534
+type DiagnosticTag uint32
+
 // Workspace client capabilities specific to diagnostic pull requests.
 //
 // @since 3.17.0
-type DiagnosticWorkspaceClientCapabilities struct { // line 11111
+type DiagnosticWorkspaceClientCapabilities struct {
 	// Whether the client implementation supports a refresh request sent from
 	// the server to the client.
 	//
@@ -973,24 +1287,24 @@ type DiagnosticWorkspaceClientCapabilities struct { // line 11111
 	// change that requires such a calculation.
 	RefreshSupport bool `json:"refreshSupport,omitempty"`
 }
-type DidChangeConfigurationClientCapabilities struct { // line 10837
+type DidChangeConfigurationClientCapabilities struct {
 	// Did change configuration notification supports dynamic registration.
 	DynamicRegistration bool `json:"dynamicRegistration,omitempty"`
 }
 
 // The parameters of a change configuration notification.
-type DidChangeConfigurationParams struct { // line 4144
+type DidChangeConfigurationParams struct {
 	// The actual changed settings
 	Settings interface{} `json:"settings"`
 }
-type DidChangeConfigurationRegistrationOptions struct { // line 4158
+type DidChangeConfigurationRegistrationOptions struct {
 	Section *OrPSection_workspace_didChangeConfiguration `json:"section,omitempty"`
 }
 
 // The params sent in a change notebook document notification.
 //
 // @since 3.17.0
-type DidChangeNotebookDocumentParams struct { // line 3974
+type DidChangeNotebookDocumentParams struct {
 	// The notebook document that did change. The version number points
 	// to the version after all provided changes have been applied. If
 	// only the text document content of a cell changes the notebook version
@@ -1014,7 +1328,7 @@ type DidChangeNotebookDocumentParams struct { // line 3974
 }
 
 // The change text document notification's parameters.
-type DidChangeTextDocumentParams struct { // line 4287
+type DidChangeTextDocumentParams struct {
 	// The document that did change. The version number points
 	// to the version after all provided content changes have
 	// been applied.
@@ -1033,7 +1347,7 @@ type DidChangeTextDocumentParams struct { // line 4287
 	//   you receive them.
 	ContentChanges []TextDocumentContentChangeEvent `json:"contentChanges"`
 }
-type DidChangeWatchedFilesClientCapabilities struct { // line 10851
+type DidChangeWatchedFilesClientCapabilities struct {
 	// Did change watched files notification supports dynamic registration. Please note
 	// that the current protocol doesn't support static configuration for file changes
 	// from the server side.
@@ -1046,19 +1360,19 @@ type DidChangeWatchedFilesClientCapabilities struct { // line 10851
 }
 
 // The watched files change notification's parameters.
-type DidChangeWatchedFilesParams struct { // line 4428
+type DidChangeWatchedFilesParams struct {
 	// The actual file events.
 	Changes []FileEvent `json:"changes"`
 }
 
 // Describe options to be used when registered for text document change events.
-type DidChangeWatchedFilesRegistrationOptions struct { // line 4445
+type DidChangeWatchedFilesRegistrationOptions struct {
 	// The watchers to register.
 	Watchers []FileSystemWatcher `json:"watchers"`
 }
 
 // The parameters of a `workspace/didChangeWorkspaceFolders` notification.
-type DidChangeWorkspaceFoldersParams struct { // line 2185
+type DidChangeWorkspaceFoldersParams struct {
 	// The actual workspace folder change event.
 	Event WorkspaceFoldersChangeEvent `json:"event"`
 }
@@ -1066,7 +1380,7 @@ type DidChangeWorkspaceFoldersParams struct { // line 2185
 // The params sent in a close notebook document notification.
 //
 // @since 3.17.0
-type DidCloseNotebookDocumentParams struct { // line 4012
+type DidCloseNotebookDocumentParams struct {
 	// The notebook document that got closed.
 	NotebookDocument NotebookDocumentIdentifier `json:"notebookDocument"`
 	// The text documents that represent the content
@@ -1075,7 +1389,7 @@ type DidCloseNotebookDocumentParams struct { // line 4012
 }
 
 // The parameters sent in a close text document notification
-type DidCloseTextDocumentParams struct { // line 4332
+type DidCloseTextDocumentParams struct {
 	// The document that was closed.
 	TextDocument TextDocumentIdentifier `json:"textDocument"`
 }
@@ -1083,7 +1397,7 @@ type DidCloseTextDocumentParams struct { // line 4332
 // The params sent in an open notebook document notification.
 //
 // @since 3.17.0
-type DidOpenNotebookDocumentParams struct { // line 3948
+type DidOpenNotebookDocumentParams struct {
 	// The notebook document that got opened.
 	NotebookDocument NotebookDocument `json:"notebookDocument"`
 	// The text documents that represent the content
@@ -1092,7 +1406,7 @@ type DidOpenNotebookDocumentParams struct { // line 3948
 }
 
 // The parameters sent in an open text document notification
-type DidOpenTextDocumentParams struct { // line 4273
+type DidOpenTextDocumentParams struct {
 	// The document that was opened.
 	TextDocument TextDocumentItem `json:"textDocument"`
 }
@@ -1100,37 +1414,37 @@ type DidOpenTextDocumentParams struct { // line 4273
 // The params sent in a save notebook document notification.
 //
 // @since 3.17.0
-type DidSaveNotebookDocumentParams struct { // line 3997
+type DidSaveNotebookDocumentParams struct {
 	// The notebook document that got saved.
 	NotebookDocument NotebookDocumentIdentifier `json:"notebookDocument"`
 }
 
 // The parameters sent in a save text document notification
-type DidSaveTextDocumentParams struct { // line 4346
+type DidSaveTextDocumentParams struct {
 	// The document that was saved.
 	TextDocument TextDocumentIdentifier `json:"textDocument"`
 	// Optional the content when saved. Depends on the includeText value
 	// when the save notification was requested.
 	Text *string `json:"text,omitempty"`
 }
-type DocumentColorClientCapabilities struct { // line 11875
+type DocumentColorClientCapabilities struct {
 	// Whether implementation supports dynamic registration. If this is set to `true`
 	// the client supports the new `DocumentColorRegistrationOptions` return value
 	// for the corresponding server capability as well.
 	DynamicRegistration bool `json:"dynamicRegistration,omitempty"`
 }
-type DocumentColorOptions struct { // line 6471
+type DocumentColorOptions struct {
 	WorkDoneProgressOptions
 }
 
 // Parameters for a {@link DocumentColorRequest}.
-type DocumentColorParams struct { // line 2215
+type DocumentColorParams struct {
 	// The text document.
 	TextDocument TextDocumentIdentifier `json:"textDocument"`
 	WorkDoneProgressParams
 	PartialResultParams
 }
-type DocumentColorRegistrationOptions struct { // line 2261
+type DocumentColorRegistrationOptions struct {
 	TextDocumentRegistrationOptions
 	DocumentColorOptions
 	StaticRegistrationOptions
@@ -1139,7 +1453,7 @@ type DocumentColorRegistrationOptions struct { // line 2261
 // Parameters of the document diagnostic request.
 //
 // @since 3.17.0
-type DocumentDiagnosticParams struct { // line 3768
+type DocumentDiagnosticParams struct {
 	// The text document.
 	TextDocument TextDocumentIdentifier `json:"textDocument"`
 	// The additional identifier  provided during registration.
@@ -1149,15 +1463,16 @@ type DocumentDiagnosticParams struct { // line 3768
 	WorkDoneProgressParams
 	PartialResultParams
 }
-type DocumentDiagnosticReport = Or_DocumentDiagnosticReport // (alias) line 13909
+type DocumentDiagnosticReport = Or_DocumentDiagnosticReport // (alias)
 // The document diagnostic report kinds.
 //
 // @since 3.17.0
-type DocumentDiagnosticReportKind string // line 12722
+type DocumentDiagnosticReportKind string
+
 // A partial result for a document diagnostic report.
 //
 // @since 3.17.0
-type DocumentDiagnosticReportPartialResult struct { // line 3811
+type DocumentDiagnosticReportPartialResult struct {
 	RelatedDocuments map[DocumentURI]interface{} `json:"relatedDocuments"`
 }
 
@@ -1165,20 +1480,20 @@ type DocumentDiagnosticReportPartialResult struct { // line 3811
 // a notebook cell document.
 //
 // @since 3.17.0 - proposed support for NotebookCellTextDocumentFilter.
-type DocumentFilter = Or_DocumentFilter // (alias) line 14093
+type DocumentFilter = Or_DocumentFilter // (alias)
 // Client capabilities of a {@link DocumentFormattingRequest}.
-type DocumentFormattingClientCapabilities struct { // line 11889
+type DocumentFormattingClientCapabilities struct {
 	// Whether formatting supports dynamic registration.
 	DynamicRegistration bool `json:"dynamicRegistration,omitempty"`
 }
 
 // Provider options for a {@link DocumentFormattingRequest}.
-type DocumentFormattingOptions struct { // line 9221
+type DocumentFormattingOptions struct {
 	WorkDoneProgressOptions
 }
 
 // The parameters of a {@link DocumentFormattingRequest}.
-type DocumentFormattingParams struct { // line 5727
+type DocumentFormattingParams struct {
 	// The document to format.
 	TextDocument TextDocumentIdentifier `json:"textDocument"`
 	// The format options.
@@ -1187,7 +1502,7 @@ type DocumentFormattingParams struct { // line 5727
 }
 
 // Registration options for a {@link DocumentFormattingRequest}.
-type DocumentFormattingRegistrationOptions struct { // line 5755
+type DocumentFormattingRegistrationOptions struct {
 	TextDocumentRegistrationOptions
 	DocumentFormattingOptions
 }
@@ -1195,7 +1510,7 @@ type DocumentFormattingRegistrationOptions struct { // line 5755
 // A document highlight is a range inside a text document which deserves
 // special attention. Usually a document highlight is visualized by changing
 // the background color of its range.
-type DocumentHighlight struct { // line 5119
+type DocumentHighlight struct {
 	// The range this highlight applies to.
 	Range Range `json:"range"`
 	// The highlight kind, default is {@link DocumentHighlightKind.Text text}.
@@ -1203,38 +1518,39 @@ type DocumentHighlight struct { // line 5119
 }
 
 // Client Capabilities for a {@link DocumentHighlightRequest}.
-type DocumentHighlightClientCapabilities struct { // line 11624
+type DocumentHighlightClientCapabilities struct {
 	// Whether document highlight supports dynamic registration.
 	DynamicRegistration bool `json:"dynamicRegistration,omitempty"`
 }
 
 // A document highlight kind.
-type DocumentHighlightKind uint32 // line 13301
+type DocumentHighlightKind uint32
+
 // Provider options for a {@link DocumentHighlightRequest}.
-type DocumentHighlightOptions struct { // line 8955
+type DocumentHighlightOptions struct {
 	WorkDoneProgressOptions
 }
 
 // Parameters for a {@link DocumentHighlightRequest}.
-type DocumentHighlightParams struct { // line 5098
+type DocumentHighlightParams struct {
 	TextDocumentPositionParams
 	WorkDoneProgressParams
 	PartialResultParams
 }
 
 // Registration options for a {@link DocumentHighlightRequest}.
-type DocumentHighlightRegistrationOptions struct { // line 5142
+type DocumentHighlightRegistrationOptions struct {
 	TextDocumentRegistrationOptions
 	DocumentHighlightOptions
 }
 
 // A document link is a range in a text document that links to an internal or external resource, like another
 // text document or a web site.
-type DocumentLink struct { // line 5670
+type DocumentLink struct {
 	// The range this link applies to.
 	Range Range `json:"range"`
 	// The uri this link points to. If missing a resolve request is sent later.
-	Target string `json:"target,omitempty"`
+	Target *URI `json:"target,omitempty"`
 	// The tooltip text when you hover over this link.
 	//
 	// If a tooltip is provided, is will be displayed in a string that includes instructions on how to
@@ -1249,7 +1565,7 @@ type DocumentLink struct { // line 5670
 }
 
 // The client capabilities of a {@link DocumentLinkRequest}.
-type DocumentLinkClientCapabilities struct { // line 11850
+type DocumentLinkClientCapabilities struct {
 	// Whether document link supports dynamic registration.
 	DynamicRegistration bool `json:"dynamicRegistration,omitempty"`
 	// Whether the client supports the `tooltip` property on `DocumentLink`.
@@ -1259,14 +1575,14 @@ type DocumentLinkClientCapabilities struct { // line 11850
 }
 
 // Provider options for a {@link DocumentLinkRequest}.
-type DocumentLinkOptions struct { // line 9148
+type DocumentLinkOptions struct {
 	// Document links have a resolve provider as well.
 	ResolveProvider bool `json:"resolveProvider,omitempty"`
 	WorkDoneProgressOptions
 }
 
 // The parameters of a {@link DocumentLinkRequest}.
-type DocumentLinkParams struct { // line 5646
+type DocumentLinkParams struct {
 	// The document to provide document links for.
 	TextDocument TextDocumentIdentifier `json:"textDocument"`
 	WorkDoneProgressParams
@@ -1274,19 +1590,19 @@ type DocumentLinkParams struct { // line 5646
 }
 
 // Registration options for a {@link DocumentLinkRequest}.
-type DocumentLinkRegistrationOptions struct { // line 5712
+type DocumentLinkRegistrationOptions struct {
 	TextDocumentRegistrationOptions
 	DocumentLinkOptions
 }
 
 // Client capabilities of a {@link DocumentOnTypeFormattingRequest}.
-type DocumentOnTypeFormattingClientCapabilities struct { // line 11919
+type DocumentOnTypeFormattingClientCapabilities struct {
 	// Whether on type formatting supports dynamic registration.
 	DynamicRegistration bool `json:"dynamicRegistration,omitempty"`
 }
 
 // Provider options for a {@link DocumentOnTypeFormattingRequest}.
-type DocumentOnTypeFormattingOptions struct { // line 9243
+type DocumentOnTypeFormattingOptions struct {
 	// A character on which formatting should be triggered, like `{`.
 	FirstTriggerCharacter string `json:"firstTriggerCharacter"`
 	// More trigger characters.
@@ -1294,7 +1610,7 @@ type DocumentOnTypeFormattingOptions struct { // line 9243
 }
 
 // The parameters of a {@link DocumentOnTypeFormattingRequest}.
-type DocumentOnTypeFormattingParams struct { // line 5821
+type DocumentOnTypeFormattingParams struct {
 	// The document to format.
 	TextDocument TextDocumentIdentifier `json:"textDocument"`
 	// The position around which the on type formatting should happen.
@@ -1311,24 +1627,34 @@ type DocumentOnTypeFormattingParams struct { // line 5821
 }
 
 // Registration options for a {@link DocumentOnTypeFormattingRequest}.
-type DocumentOnTypeFormattingRegistrationOptions struct { // line 5859
+type DocumentOnTypeFormattingRegistrationOptions struct {
 	TextDocumentRegistrationOptions
 	DocumentOnTypeFormattingOptions
 }
 
 // Client capabilities of a {@link DocumentRangeFormattingRequest}.
-type DocumentRangeFormattingClientCapabilities struct { // line 11904
+type DocumentRangeFormattingClientCapabilities struct {
 	// Whether range formatting supports dynamic registration.
 	DynamicRegistration bool `json:"dynamicRegistration,omitempty"`
+	// Whether the client supports formatting multiple ranges at once.
+	//
+	// @since 3.18.0
+	// @proposed
+	RangesSupport bool `json:"rangesSupport,omitempty"`
 }
 
 // Provider options for a {@link DocumentRangeFormattingRequest}.
-type DocumentRangeFormattingOptions struct { // line 9232
+type DocumentRangeFormattingOptions struct {
+	// Whether the server supports formatting multiple ranges at once.
+	//
+	// @since 3.18.0
+	// @proposed
+	RangesSupport bool `json:"rangesSupport,omitempty"`
 	WorkDoneProgressOptions
 }
 
 // The parameters of a {@link DocumentRangeFormattingRequest}.
-type DocumentRangeFormattingParams struct { // line 5770
+type DocumentRangeFormattingParams struct {
 	// The document to format.
 	TextDocument TextDocumentIdentifier `json:"textDocument"`
 	// The range to format
@@ -1339,9 +1665,23 @@ type DocumentRangeFormattingParams struct { // line 5770
 }
 
 // Registration options for a {@link DocumentRangeFormattingRequest}.
-type DocumentRangeFormattingRegistrationOptions struct { // line 5806
+type DocumentRangeFormattingRegistrationOptions struct {
 	TextDocumentRegistrationOptions
 	DocumentRangeFormattingOptions
+}
+
+// The parameters of a {@link DocumentRangesFormattingRequest}.
+//
+// @since 3.18.0
+// @proposed
+type DocumentRangesFormattingParams struct {
+	// The document to format.
+	TextDocument TextDocumentIdentifier `json:"textDocument"`
+	// The ranges to format
+	Ranges []Range `json:"ranges"`
+	// The format options
+	Options FormattingOptions `json:"options"`
+	WorkDoneProgressParams
 }
 
 // A document selector is the combination of one or many document filters.
@@ -1349,12 +1689,12 @@ type DocumentRangeFormattingRegistrationOptions struct { // line 5806
 // @sample `let sel:DocumentSelector = [{ language: 'typescript' }, { language: 'json', pattern: '**∕tsconfig.json' }]`;
 //
 // The use of a string as a document filter is deprecated @since 3.16.0.
-type DocumentSelector = []DocumentFilter // (alias) line 13948
+type DocumentSelector = []DocumentFilter // (alias)
 // Represents programming constructs like variables, classes, interfaces etc.
 // that appear in a document. Document symbols can be hierarchical and they
 // have two ranges: one that encloses its definition and one that points to
 // its most interesting range, e.g. the range of an identifier.
-type DocumentSymbol struct { // line 5211
+type DocumentSymbol struct {
 	// The name of this symbol. Will be displayed in the user interface and therefore must not be
 	// an empty string or a string only consisting of white spaces.
 	Name string `json:"name"`
@@ -1382,12 +1722,12 @@ type DocumentSymbol struct { // line 5211
 }
 
 // Client Capabilities for a {@link DocumentSymbolRequest}.
-type DocumentSymbolClientCapabilities struct { // line 11639
+type DocumentSymbolClientCapabilities struct {
 	// Whether document symbol supports dynamic registration.
 	DynamicRegistration bool `json:"dynamicRegistration,omitempty"`
 	// Specific capabilities for the `SymbolKind` in the
 	// `textDocument/documentSymbol` request.
-	SymbolKind *PSymbolKindPDocumentSymbol `json:"symbolKind,omitempty"`
+	SymbolKind *ClientSymbolKindOptions `json:"symbolKind,omitempty"`
 	// The client supports hierarchical document symbols.
 	HierarchicalDocumentSymbolSupport bool `json:"hierarchicalDocumentSymbolSupport,omitempty"`
 	// The client supports tags on `SymbolInformation`. Tags are supported on
@@ -1395,7 +1735,7 @@ type DocumentSymbolClientCapabilities struct { // line 11639
 	// Clients supporting tags have to handle unknown tags gracefully.
 	//
 	// @since 3.16.0
-	TagSupport *PTagSupportPDocumentSymbol `json:"tagSupport,omitempty"`
+	TagSupport *ClientSymbolTagOptions `json:"tagSupport,omitempty"`
 	// The client supports an additional label presented in the UI when
 	// registering a document symbol provider.
 	//
@@ -1404,7 +1744,7 @@ type DocumentSymbolClientCapabilities struct { // line 11639
 }
 
 // Provider options for a {@link DocumentSymbolRequest}.
-type DocumentSymbolOptions struct { // line 9010
+type DocumentSymbolOptions struct {
 	// A human-readable string that is shown when multiple outlines trees
 	// are shown for the same document.
 	//
@@ -1414,7 +1754,7 @@ type DocumentSymbolOptions struct { // line 9010
 }
 
 // Parameters for a {@link DocumentSymbolRequest}.
-type DocumentSymbolParams struct { // line 5157
+type DocumentSymbolParams struct {
 	// The text document.
 	TextDocument TextDocumentIdentifier `json:"textDocument"`
 	WorkDoneProgressParams
@@ -1422,29 +1762,40 @@ type DocumentSymbolParams struct { // line 5157
 }
 
 // Registration options for a {@link DocumentSymbolRequest}.
-type DocumentSymbolRegistrationOptions struct { // line 5293
+type DocumentSymbolRegistrationOptions struct {
 	TextDocumentRegistrationOptions
 	DocumentSymbolOptions
 }
+
+// Edit range variant that includes ranges for insert and replace operations.
+//
+// @since 3.18.0
+// @proposed
+type EditRangeWithInsertReplace struct {
+	Insert  Range `json:"insert"`
+	Replace Range `json:"replace"`
+}
+
 type DocumentURI string
 
 // Predefined error codes.
-type ErrorCodes int32 // line 12743
+type ErrorCodes int32
+
 // The client capabilities of a {@link ExecuteCommandRequest}.
-type ExecuteCommandClientCapabilities struct { // line 10962
+type ExecuteCommandClientCapabilities struct {
 	// Execute command supports dynamic registration.
 	DynamicRegistration bool `json:"dynamicRegistration,omitempty"`
 }
 
 // The server capabilities of a {@link ExecuteCommandRequest}.
-type ExecuteCommandOptions struct { // line 9291
+type ExecuteCommandOptions struct {
 	// The commands to be executed on the server
 	Commands []string `json:"commands"`
 	WorkDoneProgressOptions
 }
 
 // The parameters of a {@link ExecuteCommandRequest}.
-type ExecuteCommandParams struct { // line 5941
+type ExecuteCommandParams struct {
 	// The identifier of the actual command handler.
 	Command string `json:"command"`
 	// Arguments that the command should be invoked with.
@@ -1453,10 +1804,10 @@ type ExecuteCommandParams struct { // line 5941
 }
 
 // Registration options for a {@link ExecuteCommandRequest}.
-type ExecuteCommandRegistrationOptions struct { // line 5973
+type ExecuteCommandRegistrationOptions struct {
 	ExecuteCommandOptions
 }
-type ExecutionSummary struct { // line 10162
+type ExecutionSummary struct {
 	// A strict monotonically increasing value
 	// indicating the execution order of a cell
 	// inside a notebook.
@@ -1465,75 +1816,15 @@ type ExecutionSummary struct { // line 10162
 	// not if known by the client.
 	Success bool `json:"success,omitempty"`
 }
+type FailureHandlingKind string
 
-// created for Literal (Lit_CodeActionClientCapabilities_codeActionLiteralSupport_codeActionKind)
-type FCodeActionKindPCodeActionLiteralSupport struct { // line 11742
-	// The code action kind values the client supports. When this
-	// property exists the client also guarantees that it will
-	// handle values outside its set gracefully and falls back
-	// to a default value when unknown.
-	ValueSet []CodeActionKind `json:"valueSet"`
-}
-
-// created for Literal (Lit_CompletionList_itemDefaults_editRange_Item1)
-type FEditRangePItemDefaults struct { // line 4777
-	Insert  Range `json:"insert"`
-	Replace Range `json:"replace"`
-}
-
-// created for Literal (Lit_SemanticTokensClientCapabilities_requests_full_Item1)
-type FFullPRequests struct { // line 12205
-	// The client will send the `textDocument/semanticTokens/full/delta` request if
-	// the server provides a corresponding handler.
-	Delta bool `json:"delta"`
-}
-
-// created for Literal (Lit_CompletionClientCapabilities_completionItem_insertTextModeSupport)
-type FInsertTextModeSupportPCompletionItem struct { // line 11295
-	ValueSet []InsertTextMode `json:"valueSet"`
-}
-
-// created for Literal (Lit_SignatureHelpClientCapabilities_signatureInformation_parameterInformation)
-type FParameterInformationPSignatureInformation struct { // line 11461
-	// The client supports processing label offsets instead of a
-	// simple label string.
-	//
-	// @since 3.14.0
-	LabelOffsetSupport bool `json:"labelOffsetSupport,omitempty"`
-}
-
-// created for Literal (Lit_SemanticTokensClientCapabilities_requests_range_Item1)
-type FRangePRequests struct { // line 12185
-}
-
-// created for Literal (Lit_CompletionClientCapabilities_completionItem_resolveSupport)
-type FResolveSupportPCompletionItem struct { // line 11271
-	// The properties that a client can resolve lazily.
-	Properties []string `json:"properties"`
-}
-
-// created for Literal (Lit_NotebookDocumentChangeEvent_cells_structure)
-type FStructurePCells struct { // line 7487
-	// The change to the cell array.
-	Array NotebookCellArrayChange `json:"array"`
-	// Additional opened cell text documents.
-	DidOpen []TextDocumentItem `json:"didOpen,omitempty"`
-	// Additional closed cell text documents.
-	DidClose []TextDocumentIdentifier `json:"didClose,omitempty"`
-}
-
-// created for Literal (Lit_CompletionClientCapabilities_completionItem_tagSupport)
-type FTagSupportPCompletionItem struct { // line 11237
-	// The tags supported by the client.
-	ValueSet []CompletionItemTag `json:"valueSet"`
-}
-type FailureHandlingKind string // line 13693
 // The file event type
-type FileChangeType uint32 // line 13454
+type FileChangeType uint32
+
 // Represents information on a file/folder create.
 //
 // @since 3.16.0
-type FileCreate struct { // line 6662
+type FileCreate struct {
 	// A file:// URI for the location of the file/folder being created.
 	URI string `json:"uri"`
 }
@@ -1541,13 +1832,13 @@ type FileCreate struct { // line 6662
 // Represents information on a file/folder delete.
 //
 // @since 3.16.0
-type FileDelete struct { // line 6911
+type FileDelete struct {
 	// A file:// URI for the location of the file/folder being deleted.
 	URI string `json:"uri"`
 }
 
 // An event describing a file change.
-type FileEvent struct { // line 8480
+type FileEvent struct {
 	// The file's uri.
 	URI DocumentURI `json:"uri"`
 	// The change type.
@@ -1560,7 +1851,7 @@ type FileEvent struct { // line 8480
 // like renaming a file in the UI.
 //
 // @since 3.16.0
-type FileOperationClientCapabilities struct { // line 11009
+type FileOperationClientCapabilities struct {
 	// Whether the client supports dynamic registration for file requests/notifications.
 	DynamicRegistration bool `json:"dynamicRegistration,omitempty"`
 	// The client has support for sending didCreateFiles notifications.
@@ -1581,7 +1872,7 @@ type FileOperationClientCapabilities struct { // line 11009
 // the server is interested in receiving.
 //
 // @since 3.16.0
-type FileOperationFilter struct { // line 6864
+type FileOperationFilter struct {
 	// A Uri scheme like `file` or `untitled`.
 	Scheme string `json:"scheme,omitempty"`
 	// The actual file operation pattern.
@@ -1591,7 +1882,7 @@ type FileOperationFilter struct { // line 6864
 // Options for notifications/requests for user operations on files.
 //
 // @since 3.16.0
-type FileOperationOptions struct { // line 9965
+type FileOperationOptions struct {
 	// The server is interested in receiving didCreateFiles notifications.
 	DidCreate *FileOperationRegistrationOptions `json:"didCreate,omitempty"`
 	// The server is interested in receiving willCreateFiles requests.
@@ -1610,7 +1901,7 @@ type FileOperationOptions struct { // line 9965
 // the server is interested in receiving.
 //
 // @since 3.16.0
-type FileOperationPattern struct { // line 9489
+type FileOperationPattern struct {
 	// The glob pattern to match. Glob patterns can have the following syntax:
 	//
 	//  - `*` to match one or more characters in a path segment
@@ -1632,11 +1923,12 @@ type FileOperationPattern struct { // line 9489
 // both.
 //
 // @since 3.16.0
-type FileOperationPatternKind string // line 13627
+type FileOperationPatternKind string
+
 // Matching options for the file operation pattern.
 //
 // @since 3.16.0
-type FileOperationPatternOptions struct { // line 10146
+type FileOperationPatternOptions struct {
 	// The pattern should be matched ignoring casing.
 	IgnoreCase bool `json:"ignoreCase,omitempty"`
 }
@@ -1644,7 +1936,7 @@ type FileOperationPatternOptions struct { // line 10146
 // The options to register for file operations.
 //
 // @since 3.16.0
-type FileOperationRegistrationOptions struct { // line 3264
+type FileOperationRegistrationOptions struct {
 	// The actual filters.
 	Filters []FileOperationFilter `json:"filters"`
 }
@@ -1652,13 +1944,13 @@ type FileOperationRegistrationOptions struct { // line 3264
 // Represents information on a file/folder rename.
 //
 // @since 3.16.0
-type FileRename struct { // line 6888
+type FileRename struct {
 	// A file:// URI for the original location of the file/folder being renamed.
 	OldURI string `json:"oldUri"`
 	// A file:// URI for the new location of the file/folder being renamed.
 	NewURI string `json:"newUri"`
 }
-type FileSystemWatcher struct { // line 8502
+type FileSystemWatcher struct {
 	// The glob pattern to watch. See {@link GlobPattern glob pattern} for more detail.
 	//
 	// @since 3.17.0 support for relative patterns.
@@ -1671,7 +1963,7 @@ type FileSystemWatcher struct { // line 8502
 
 // Represents a folding range. To be valid, start and end line must be bigger than zero and smaller
 // than the number of lines in the document. Clients are free to ignore invalid ranges.
-type FoldingRange struct { // line 2415
+type FoldingRange struct {
 	// The zero-based start line of the range to fold. The folded area starts after the line's last character.
 	// To be valid, the end must be zero or larger and smaller than the number of lines in the document.
 	StartLine uint32 `json:"startLine"`
@@ -1693,7 +1985,7 @@ type FoldingRange struct { // line 2415
 	// @since 3.17.0
 	CollapsedText string `json:"collapsedText,omitempty"`
 }
-type FoldingRangeClientCapabilities struct { // line 11978
+type FoldingRangeClientCapabilities struct {
 	// Whether implementation supports dynamic registration for folding range
 	// providers. If this is set to `true` the client supports the new
 	// `FoldingRangeRegistrationOptions` return value for the corresponding
@@ -1710,34 +2002,52 @@ type FoldingRangeClientCapabilities struct { // line 11978
 	// Specific options for the folding range kind.
 	//
 	// @since 3.17.0
-	FoldingRangeKind *PFoldingRangeKindPFoldingRange `json:"foldingRangeKind,omitempty"`
+	FoldingRangeKind *ClientFoldingRangeKindOptions `json:"foldingRangeKind,omitempty"`
 	// Specific options for the folding range.
 	//
 	// @since 3.17.0
-	FoldingRange *PFoldingRangePFoldingRange `json:"foldingRange,omitempty"`
+	FoldingRange *ClientFoldingRangeOptions `json:"foldingRange,omitempty"`
 }
 
 // A set of predefined range kinds.
-type FoldingRangeKind string      // line 12815
-type FoldingRangeOptions struct { // line 6481
+type FoldingRangeKind string
+type FoldingRangeOptions struct {
 	WorkDoneProgressOptions
 }
 
 // Parameters for a {@link FoldingRangeRequest}.
-type FoldingRangeParams struct { // line 2391
+type FoldingRangeParams struct {
 	// The text document.
 	TextDocument TextDocumentIdentifier `json:"textDocument"`
 	WorkDoneProgressParams
 	PartialResultParams
 }
-type FoldingRangeRegistrationOptions struct { // line 2474
+type FoldingRangeRegistrationOptions struct {
 	TextDocumentRegistrationOptions
 	FoldingRangeOptions
 	StaticRegistrationOptions
 }
 
+// Client workspace capabilities specific to folding ranges
+//
+// @since 3.18.0
+// @proposed
+type FoldingRangeWorkspaceClientCapabilities struct {
+	// Whether the client implementation supports a refresh request sent from the
+	// server to the client.
+	//
+	// Note that this event is global and will force the client to refresh all
+	// folding ranges currently shown. It should be used with absolute care and is
+	// useful for situation where a server for example detects a project wide
+	// change that requires such a calculation.
+	//
+	// @since 3.18.0
+	// @proposed
+	RefreshSupport bool `json:"refreshSupport,omitempty"`
+}
+
 // Value-object describing what options formatting should use.
-type FormattingOptions struct { // line 9169
+type FormattingOptions struct {
 	// Size of a tab in spaces.
 	TabSize uint32 `json:"tabSize"`
 	// Prefer spaces over tabs.
@@ -1759,7 +2069,7 @@ type FormattingOptions struct { // line 9169
 // A diagnostic report with a full set of problems.
 //
 // @since 3.17.0
-type FullDocumentDiagnosticReport struct { // line 7235
+type FullDocumentDiagnosticReport struct {
 	// A full document diagnostic report.
 	Kind string `json:"kind"`
 	// An optional result id. If provided it will
@@ -1773,14 +2083,14 @@ type FullDocumentDiagnosticReport struct { // line 7235
 // General client capabilities.
 //
 // @since 3.16.0
-type GeneralClientCapabilities struct { // line 10664
+type GeneralClientCapabilities struct {
 	// Client capability that signals how the client
 	// handles stale requests (e.g. a request
 	// for which the client will not process the response
 	// anymore since the information is outdated).
 	//
 	// @since 3.17.0
-	StaleRequestSupport *PStaleRequestSupportPGeneral `json:"staleRequestSupport,omitempty"`
+	StaleRequestSupport *StaleRequestSupportOptions `json:"staleRequestSupport,omitempty"`
 	// Client capabilities specific to regular expressions.
 	//
 	// @since 3.16.0
@@ -1813,16 +2123,16 @@ type GeneralClientCapabilities struct { // line 10664
 // The glob pattern. Either a string pattern or a relative pattern.
 //
 // @since 3.17.0
-type GlobPattern = string // (alias) line 14127
+type GlobPattern = string // (alias)
 // The result of a hover request.
-type Hover struct { // line 4886
+type Hover struct {
 	// The hover's content
 	Contents MarkupContent `json:"contents"`
 	// An optional range inside the text document that is used to
 	// visualize the hover, e.g. by changing the background color.
 	Range Range `json:"range,omitempty"`
 }
-type HoverClientCapabilities struct { // line 11402
+type HoverClientCapabilities struct {
 	// Whether hover supports dynamic registration.
 	DynamicRegistration bool `json:"dynamicRegistration,omitempty"`
 	// Client supports the following content formats for the content
@@ -1831,24 +2141,24 @@ type HoverClientCapabilities struct { // line 11402
 }
 
 // Hover options.
-type HoverOptions struct { // line 8776
+type HoverOptions struct {
 	WorkDoneProgressOptions
 }
 
 // Parameters for a {@link HoverRequest}.
-type HoverParams struct { // line 4869
+type HoverParams struct {
 	TextDocumentPositionParams
 	WorkDoneProgressParams
 }
 
 // Registration options for a {@link HoverRequest}.
-type HoverRegistrationOptions struct { // line 4925
+type HoverRegistrationOptions struct {
 	TextDocumentRegistrationOptions
 	HoverOptions
 }
 
 // @since 3.6.0
-type ImplementationClientCapabilities struct { // line 11583
+type ImplementationClientCapabilities struct {
 	// Whether implementation supports dynamic registration. If this is set to `true`
 	// the client supports the new `ImplementationRegistrationOptions` return value
 	// for the corresponding server capability as well.
@@ -1858,15 +2168,15 @@ type ImplementationClientCapabilities struct { // line 11583
 	// @since 3.14.0
 	LinkSupport bool `json:"linkSupport,omitempty"`
 }
-type ImplementationOptions struct { // line 6333
+type ImplementationOptions struct {
 	WorkDoneProgressOptions
 }
-type ImplementationParams struct { // line 2063
+type ImplementationParams struct {
 	TextDocumentPositionParams
 	WorkDoneProgressParams
 	PartialResultParams
 }
-type ImplementationRegistrationOptions struct { // line 2103
+type ImplementationRegistrationOptions struct {
 	TextDocumentRegistrationOptions
 	ImplementationOptions
 	StaticRegistrationOptions
@@ -1874,34 +2184,34 @@ type ImplementationRegistrationOptions struct { // line 2103
 
 // The data type of the ResponseError if the
 // initialize request fails.
-type InitializeError struct { // line 4126
+type InitializeError struct {
 	// Indicates whether the client execute the following retry logic:
 	// (1) show the message provided by the ResponseError to the user
 	// (2) user selects retry or cancel
 	// (3) if user selected retry the initialize method is sent again.
 	Retry bool `json:"retry"`
 }
-type InitializeParams struct { // line 4068
+type InitializeParams struct {
 	XInitializeParams
 	WorkspaceFoldersInitializeParams
 }
 
 // The result returned from an initialize request.
-type InitializeResult struct { // line 4082
+type InitializeResult struct {
 	// The capabilities the language server provides.
 	Capabilities ServerCapabilities `json:"capabilities"`
 	// Information about the server.
 	//
 	// @since 3.15.0
-	ServerInfo *PServerInfoMsg_initialize `json:"serverInfo,omitempty"`
+	ServerInfo *ServerInfo `json:"serverInfo,omitempty"`
 }
-type InitializedParams struct { // line 4140
+type InitializedParams struct {
 }
 
 // Inlay hint information.
 //
 // @since 3.17.0
-type InlayHint struct { // line 3645
+type InlayHint struct {
 	// The position of this hint.
 	Position Position `json:"position"`
 	// The label of this hint. A human readable string or an array of
@@ -1940,23 +2250,24 @@ type InlayHint struct { // line 3645
 // Inlay hint client capabilities.
 //
 // @since 3.17.0
-type InlayHintClientCapabilities struct { // line 12369
+type InlayHintClientCapabilities struct {
 	// Whether inlay hints support dynamic registration.
 	DynamicRegistration bool `json:"dynamicRegistration,omitempty"`
 	// Indicates which properties a client can resolve lazily on an inlay
 	// hint.
-	ResolveSupport *PResolveSupportPInlayHint `json:"resolveSupport,omitempty"`
+	ResolveSupport *ClientInlayHintResolveOptions `json:"resolveSupport,omitempty"`
 }
 
 // Inlay hint kinds.
 //
 // @since 3.17.0
-type InlayHintKind uint32 // line 13033
+type InlayHintKind uint32
+
 // An inlay hint label part allows for interactive and composite labels
 // of inlay hints.
 //
 // @since 3.17.0
-type InlayHintLabelPart struct { // line 7062
+type InlayHintLabelPart struct {
 	// The value of this label part.
 	Value string `json:"value"`
 	// The tooltip text when you hover over this label part. Depending on
@@ -1985,7 +2296,7 @@ type InlayHintLabelPart struct { // line 7062
 // Inlay hint options used during static registration.
 //
 // @since 3.17.0
-type InlayHintOptions struct { // line 7135
+type InlayHintOptions struct {
 	// The server provides support to resolve additional
 	// information for an inlay hint item.
 	ResolveProvider bool `json:"resolveProvider,omitempty"`
@@ -1995,7 +2306,7 @@ type InlayHintOptions struct { // line 7135
 // A parameter literal used in inlay hint requests.
 //
 // @since 3.17.0
-type InlayHintParams struct { // line 3616
+type InlayHintParams struct {
 	// The text document.
 	TextDocument TextDocumentIdentifier `json:"textDocument"`
 	// The document range for which inlay hints should be computed.
@@ -2006,7 +2317,7 @@ type InlayHintParams struct { // line 3616
 // Inlay hint options used during static or dynamic registration.
 //
 // @since 3.17.0
-type InlayHintRegistrationOptions struct { // line 3746
+type InlayHintRegistrationOptions struct {
 	InlayHintOptions
 	TextDocumentRegistrationOptions
 	StaticRegistrationOptions
@@ -2015,7 +2326,7 @@ type InlayHintRegistrationOptions struct { // line 3746
 // Client workspace capabilities specific to inlay hints.
 //
 // @since 3.17.0
-type InlayHintWorkspaceClientCapabilities struct { // line 11095
+type InlayHintWorkspaceClientCapabilities struct {
 	// Whether the client implementation supports a refresh request sent from
 	// the server to the client.
 	//
@@ -2026,6 +2337,86 @@ type InlayHintWorkspaceClientCapabilities struct { // line 11095
 	RefreshSupport bool `json:"refreshSupport,omitempty"`
 }
 
+// Client capabilities specific to inline completions.
+//
+// @since 3.18.0
+// @proposed
+type InlineCompletionClientCapabilities struct {
+	// Whether implementation supports dynamic registration for inline completion providers.
+	DynamicRegistration bool `json:"dynamicRegistration,omitempty"`
+}
+
+// Provides information about the context in which an inline completion was requested.
+//
+// @since 3.18.0
+// @proposed
+type InlineCompletionContext struct {
+	// Describes how the inline completion was triggered.
+	TriggerKind InlineCompletionTriggerKind `json:"triggerKind"`
+	// Provides information about the currently selected item in the autocomplete widget if it is visible.
+	SelectedCompletionInfo *SelectedCompletionInfo `json:"selectedCompletionInfo,omitempty"`
+}
+
+// An inline completion item represents a text snippet that is proposed inline to complete text that is being typed.
+//
+// @since 3.18.0
+// @proposed
+type InlineCompletionItem struct {
+	// The text to replace the range with. Must be set.
+	InsertText Or_InlineCompletionItem_insertText `json:"insertText"`
+	// A text that is used to decide if this inline completion should be shown. When `falsy` the {@link InlineCompletionItem.insertText} is used.
+	FilterText string `json:"filterText,omitempty"`
+	// The range to replace. Must begin and end on the same line.
+	Range *Range `json:"range,omitempty"`
+	// An optional {@link Command} that is executed *after* inserting this completion.
+	Command *Command `json:"command,omitempty"`
+}
+
+// Represents a collection of {@link InlineCompletionItem inline completion items} to be presented in the editor.
+//
+// @since 3.18.0
+// @proposed
+type InlineCompletionList struct {
+	// The inline completion items
+	Items []InlineCompletionItem `json:"items"`
+}
+
+// Inline completion options used during static registration.
+//
+// @since 3.18.0
+// @proposed
+type InlineCompletionOptions struct {
+	WorkDoneProgressOptions
+}
+
+// A parameter literal used in inline completion requests.
+//
+// @since 3.18.0
+// @proposed
+type InlineCompletionParams struct {
+	// Additional information about the context in which inline completions were
+	// requested.
+	Context InlineCompletionContext `json:"context"`
+	TextDocumentPositionParams
+	WorkDoneProgressParams
+}
+
+// Inline completion options used during static or dynamic registration.
+//
+// @since 3.18.0
+// @proposed
+type InlineCompletionRegistrationOptions struct {
+	InlineCompletionOptions
+	TextDocumentRegistrationOptions
+	StaticRegistrationOptions
+}
+
+// Describes how an {@link InlineCompletionItemProvider inline completion provider} was triggered.
+//
+// @since 3.18.0
+// @proposed
+type InlineCompletionTriggerKind uint32
+
 // Inline value information can be provided by different means:
 //
 //   - directly as a text value (class InlineValueText).
@@ -2035,17 +2426,17 @@ type InlayHintWorkspaceClientCapabilities struct { // line 11095
 // The InlineValue types combines all inline value types into one type.
 //
 // @since 3.17.0
-type InlineValue = Or_InlineValue // (alias) line 13861
+type InlineValue = Or_InlineValue // (alias)
 // Client capabilities specific to inline values.
 //
 // @since 3.17.0
-type InlineValueClientCapabilities struct { // line 12353
+type InlineValueClientCapabilities struct {
 	// Whether implementation supports dynamic registration for inline value providers.
 	DynamicRegistration bool `json:"dynamicRegistration,omitempty"`
 }
 
 // @since 3.17.0
-type InlineValueContext struct { // line 6948
+type InlineValueContext struct {
 	// The stack frame (as a DAP Id) where the execution has stopped.
 	FrameID int32 `json:"frameId"`
 	// The document range where execution has stopped.
@@ -2058,7 +2449,7 @@ type InlineValueContext struct { // line 6948
 // An optional expression can be used to override the extracted expression.
 //
 // @since 3.17.0
-type InlineValueEvaluatableExpression struct { // line 7026
+type InlineValueEvaluatableExpression struct {
 	// The document range for which the inline value applies.
 	// The range is used to extract the evaluatable expression from the underlying document.
 	Range Range `json:"range"`
@@ -2069,14 +2460,14 @@ type InlineValueEvaluatableExpression struct { // line 7026
 // Inline value options used during static registration.
 //
 // @since 3.17.0
-type InlineValueOptions struct { // line 7050
+type InlineValueOptions struct {
 	WorkDoneProgressOptions
 }
 
 // A parameter literal used in inline value requests.
 //
 // @since 3.17.0
-type InlineValueParams struct { // line 3557
+type InlineValueParams struct {
 	// The text document.
 	TextDocument TextDocumentIdentifier `json:"textDocument"`
 	// The document range for which inline values should be computed.
@@ -2090,7 +2481,7 @@ type InlineValueParams struct { // line 3557
 // Inline value options used during static or dynamic registration.
 //
 // @since 3.17.0
-type InlineValueRegistrationOptions struct { // line 3594
+type InlineValueRegistrationOptions struct {
 	InlineValueOptions
 	TextDocumentRegistrationOptions
 	StaticRegistrationOptions
@@ -2099,7 +2490,7 @@ type InlineValueRegistrationOptions struct { // line 3594
 // Provide inline value as text.
 //
 // @since 3.17.0
-type InlineValueText struct { // line 6971
+type InlineValueText struct {
 	// The document range for which the inline value applies.
 	Range Range `json:"range"`
 	// The text of the inline value.
@@ -2111,7 +2502,7 @@ type InlineValueText struct { // line 6971
 // An optional variable name can be used to override the extracted name.
 //
 // @since 3.17.0
-type InlineValueVariableLookup struct { // line 6994
+type InlineValueVariableLookup struct {
 	// The document range for which the inline value applies.
 	// The range is used to extract the variable name from the underlying document.
 	Range Range `json:"range"`
@@ -2124,7 +2515,7 @@ type InlineValueVariableLookup struct { // line 6994
 // Client workspace capabilities specific to inline values.
 //
 // @since 3.17.0
-type InlineValueWorkspaceClientCapabilities struct { // line 11079
+type InlineValueWorkspaceClientCapabilities struct {
 	// Whether the client implementation supports a refresh request sent from the
 	// server to the client.
 	//
@@ -2138,7 +2529,7 @@ type InlineValueWorkspaceClientCapabilities struct { // line 11079
 // A special text edit to provide an insert and a replace operation.
 //
 // @since 3.16.0
-type InsertReplaceEdit struct { // line 8676
+type InsertReplaceEdit struct {
 	// The string to be inserted.
 	NewText string `json:"newText"`
 	// The range if the insert is requested
@@ -2149,38 +2540,40 @@ type InsertReplaceEdit struct { // line 8676
 
 // Defines whether the insert text in a completion item should be interpreted as
 // plain text or a snippet.
-type InsertTextFormat uint32 // line 13260
+type InsertTextFormat uint32
+
 // How whitespace and indentation is handled during completion
 // item insertion.
 //
 // @since 3.16.0
-type InsertTextMode uint32 // line 13280
+type InsertTextMode uint32
 type LSPAny = interface{}
 
 // LSP arrays.
 // @since 3.17.0
-type LSPArray = []interface{} // (alias) line 13779
-type LSPErrorCodes int32      // line 12783
+type LSPArray = []interface{} // (alias)
+type LSPErrorCodes int32
+
 // LSP object definition.
 // @since 3.17.0
-type LSPObject = map[string]LSPAny // (alias) line 14111
+type LSPObject = map[string]LSPAny // (alias)
 // Client capabilities for the linked editing range request.
 //
 // @since 3.16.0
-type LinkedEditingRangeClientCapabilities struct { // line 12305
+type LinkedEditingRangeClientCapabilities struct {
 	// Whether implementation supports dynamic registration. If this is set to `true`
 	// the client supports the new `(TextDocumentRegistrationOptions & StaticRegistrationOptions)`
 	// return value for the corresponding server capability as well.
 	DynamicRegistration bool `json:"dynamicRegistration,omitempty"`
 }
-type LinkedEditingRangeOptions struct { // line 6652
+type LinkedEditingRangeOptions struct {
 	WorkDoneProgressOptions
 }
-type LinkedEditingRangeParams struct { // line 3112
+type LinkedEditingRangeParams struct {
 	TextDocumentPositionParams
 	WorkDoneProgressParams
 }
-type LinkedEditingRangeRegistrationOptions struct { // line 3155
+type LinkedEditingRangeRegistrationOptions struct {
 	TextDocumentRegistrationOptions
 	LinkedEditingRangeOptions
 	StaticRegistrationOptions
@@ -2189,7 +2582,7 @@ type LinkedEditingRangeRegistrationOptions struct { // line 3155
 // The result of a linked editing range request.
 //
 // @since 3.16.0
-type LinkedEditingRanges struct { // line 3128
+type LinkedEditingRanges struct {
 	// A list of ranges that can be edited together. The ranges must have
 	// identical length and contain identical text content. The ranges cannot overlap.
 	Ranges []Range `json:"ranges"`
@@ -2199,83 +2592,20 @@ type LinkedEditingRanges struct { // line 3128
 	WordPattern string `json:"wordPattern,omitempty"`
 }
 
-// created for Literal (Lit_NotebookDocumentChangeEvent_cells_textContent_Elem)
-type Lit_NotebookDocumentChangeEvent_cells_textContent_Elem struct { // line 7545
-	Document VersionedTextDocumentIdentifier  `json:"document"`
-	Changes  []TextDocumentContentChangeEvent `json:"changes"`
-}
-
-// created for Literal (Lit_NotebookDocumentFilter_Item1)
-type Lit_NotebookDocumentFilter_Item1 struct { // line 14293
-	// The type of the enclosing notebook.
-	NotebookType string `json:"notebookType,omitempty"`
-	// A Uri {@link Uri.scheme scheme}, like `file` or `untitled`.
-	Scheme string `json:"scheme"`
-	// A glob pattern.
-	Pattern string `json:"pattern,omitempty"`
-}
-
-// created for Literal (Lit_NotebookDocumentFilter_Item2)
-type Lit_NotebookDocumentFilter_Item2 struct { // line 14326
-	// The type of the enclosing notebook.
-	NotebookType string `json:"notebookType,omitempty"`
-	// A Uri {@link Uri.scheme scheme}, like `file` or `untitled`.
-	Scheme string `json:"scheme,omitempty"`
-	// A glob pattern.
-	Pattern string `json:"pattern"`
-}
-
-// created for Literal (Lit_NotebookDocumentSyncOptions_notebookSelector_Elem_Item0_cells_Elem)
-type Lit_NotebookDocumentSyncOptions_notebookSelector_Elem_Item0_cells_Elem struct { // line 9831
-	Language string `json:"language"`
-}
-
-// created for Literal (Lit_NotebookDocumentSyncOptions_notebookSelector_Elem_Item1)
-type Lit_NotebookDocumentSyncOptions_notebookSelector_Elem_Item1 struct { // line 9852
-	// The notebook to be synced If a string
-	// value is provided it matches against the
-	// notebook type. '*' matches every notebook.
-	Notebook *Or_NotebookDocumentSyncOptions_notebookSelector_Elem_Item1_notebook `json:"notebook,omitempty"`
-	// The cells of the matching notebook to be synced.
-	Cells []Lit_NotebookDocumentSyncOptions_notebookSelector_Elem_Item1_cells_Elem `json:"cells"`
-}
-
-// created for Literal (Lit_NotebookDocumentSyncOptions_notebookSelector_Elem_Item1_cells_Elem)
-type Lit_NotebookDocumentSyncOptions_notebookSelector_Elem_Item1_cells_Elem struct { // line 9878
-	Language string `json:"language"`
-}
-
-// created for Literal (Lit_PrepareRenameResult_Item2)
-type Lit_PrepareRenameResult_Item2 struct { // line 13932
-	DefaultBehavior bool `json:"defaultBehavior"`
-}
-
-// created for Literal (Lit_TextDocumentContentChangeEvent_Item1)
-type Lit_TextDocumentContentChangeEvent_Item1 struct { // line 14040
-	// The new text of the whole document.
-	Text string `json:"text"`
-}
-
-// created for Literal (Lit_TextDocumentFilter_Item2)
-type Lit_TextDocumentFilter_Item2 struct { // line 14217
-	// A language id, like `typescript`.
-	Language string `json:"language,omitempty"`
-	// A Uri {@link Uri.scheme scheme}, like `file` or `untitled`.
-	Scheme string `json:"scheme,omitempty"`
-	// A glob pattern, like `*.{ts,js}`.
-	Pattern string `json:"pattern"`
+// created for Literal (Lit_ClientSemanticTokensRequestOptions_range_Item1)
+type Lit_ClientSemanticTokensRequestOptions_range_Item1 struct {
 }
 
 // Represents a location inside a resource, such as a line
 // inside a text file.
-type Location struct { // line 2083
+type Location struct {
 	URI   DocumentURI `json:"uri"`
 	Range Range       `json:"range"`
 }
 
 // Represents the connection of two locations. Provides additional metadata over normal {@link Location locations},
 // including an origin range.
-type LocationLink struct { // line 6272
+type LocationLink struct {
 	// Span of the origin of this link.
 	//
 	// Used as the underlined span for mouse interaction. Defaults to the word range at
@@ -2292,14 +2622,22 @@ type LocationLink struct { // line 6272
 	TargetSelectionRange Range `json:"targetSelectionRange"`
 }
 
+// Location with only uri and does not include range.
+//
+// @since 3.18.0
+// @proposed
+type LocationUriOnly struct {
+	URI DocumentURI `json:"uri"`
+}
+
 // The log message parameters.
-type LogMessageParams struct { // line 4251
+type LogMessageParams struct {
 	// The message type. See {@link MessageType}
 	Type MessageType `json:"type"`
 	// The actual message.
 	Message string `json:"message"`
 }
-type LogTraceParams struct { // line 6159
+type LogTraceParams struct {
 	Message string `json:"message"`
 	Verbose string `json:"verbose,omitempty"`
 }
@@ -2307,7 +2645,7 @@ type LogTraceParams struct { // line 6159
 // Client capabilities specific to the used markdown parser.
 //
 // @since 3.16.0
-type MarkdownClientCapabilities struct { // line 12524
+type MarkdownClientCapabilities struct {
 	// The name of the parser.
 	Parser string `json:"parser"`
 	// The version of the parser.
@@ -2331,7 +2669,15 @@ type MarkdownClientCapabilities struct { // line 12524
 //
 // Note that markdown strings will be sanitized - that means html will be escaped.
 // @deprecated use MarkupContent instead.
-type MarkedString = Or_MarkedString // (alias) line 14058
+type MarkedString = Or_MarkedString // (alias)
+// @since 3.18.0
+// @proposed
+// @deprecated use MarkupContent instead.
+type MarkedStringWithLanguage struct {
+	Language string `json:"language"`
+	Value    string `json:"value"`
+}
+
 // A `MarkupContent` literal represents a string value which content is interpreted base on its
 // kind flag. Currently the protocol supports `plaintext` and `markdown` as markup kinds.
 //
@@ -2356,7 +2702,7 @@ type MarkedString = Or_MarkedString // (alias) line 14058
 //
 // *Please Note* that clients might sanitize the return markdown. A client could decide to
 // remove HTML from the markdown to avoid script execution.
-type MarkupContent struct { // line 7113
+type MarkupContent struct {
 	// The type of the Markup
 	Kind MarkupKind `json:"kind"`
 	// The content itself
@@ -2368,18 +2714,19 @@ type MarkupContent struct { // line 7113
 //
 // Please note that `MarkupKinds` must not start with a `$`. This kinds
 // are reserved for internal usage.
-type MarkupKind string          // line 13407
-type MessageActionItem struct { // line 4238
+type MarkupKind string
+type MessageActionItem struct {
 	// A short title like 'Retry', 'Open Log' etc.
 	Title string `json:"title"`
 }
 
 // The message type
-type MessageType uint32 // line 13054
+type MessageType uint32
+
 // Moniker definition to match LSIF 0.5 moniker definition.
 //
 // @since 3.16.0
-type Moniker struct { // line 3338
+type Moniker struct {
 	// The scheme of the moniker. For example tsc or .Net
 	Scheme string `json:"scheme"`
 	// The identifier of the moniker. The value is opaque in LSIF however
@@ -2394,7 +2741,7 @@ type Moniker struct { // line 3338
 // Client capabilities specific to the moniker request.
 //
 // @since 3.16.0
-type MonikerClientCapabilities struct { // line 12321
+type MonikerClientCapabilities struct {
 	// Whether moniker supports dynamic registration. If this is set to `true`
 	// the client supports the new `MonikerRegistrationOptions` return value
 	// for the corresponding server capability as well.
@@ -2404,70 +2751,18 @@ type MonikerClientCapabilities struct { // line 12321
 // The moniker kind.
 //
 // @since 3.16.0
-type MonikerKind string      // line 13007
-type MonikerOptions struct { // line 6926
+type MonikerKind string
+type MonikerOptions struct {
 	WorkDoneProgressOptions
 }
-type MonikerParams struct { // line 3318
+type MonikerParams struct {
 	TextDocumentPositionParams
 	WorkDoneProgressParams
 	PartialResultParams
 }
-type MonikerRegistrationOptions struct { // line 3378
+type MonikerRegistrationOptions struct {
 	TextDocumentRegistrationOptions
 	MonikerOptions
-}
-
-// created for Literal (Lit_MarkedString_Item1)
-type Msg_MarkedString struct { // line 14068
-	Language string `json:"language"`
-	Value    string `json:"value"`
-}
-
-// created for Literal (Lit_NotebookDocumentFilter_Item0)
-type Msg_NotebookDocumentFilter struct { // line 14260
-	// The type of the enclosing notebook.
-	NotebookType string `json:"notebookType"`
-	// A Uri {@link Uri.scheme scheme}, like `file` or `untitled`.
-	Scheme string `json:"scheme,omitempty"`
-	// A glob pattern.
-	Pattern string `json:"pattern,omitempty"`
-}
-
-// created for Literal (Lit_PrepareRenameResult_Item1)
-type Msg_PrepareRename2Gn struct { // line 13911
-	Range       Range  `json:"range"`
-	Placeholder string `json:"placeholder"`
-}
-
-// created for Literal (Lit_TextDocumentContentChangeEvent_Item0)
-type Msg_TextDocumentContentChangeEvent struct { // line 14008
-	// The range of the document that changed.
-	Range *Range `json:"range"`
-	// The optional length of the range that got replaced.
-	//
-	// @deprecated use range instead.
-	RangeLength uint32 `json:"rangeLength,omitempty"`
-	// The new text for the provided range.
-	Text string `json:"text"`
-}
-
-// created for Literal (Lit_TextDocumentFilter_Item1)
-type Msg_TextDocumentFilter struct { // line 14184
-	// A language id, like `typescript`.
-	Language string `json:"language,omitempty"`
-	// A Uri {@link Uri.scheme scheme}, like `file` or `untitled`.
-	Scheme string `json:"scheme"`
-	// A glob pattern, like `*.{ts,js}`.
-	Pattern string `json:"pattern,omitempty"`
-}
-
-// created for Literal (Lit__InitializeParams_clientInfo)
-type Msg_XInitializeParams_clientInfo struct { // line 7673
-	// The name of the client as defined by the client.
-	Name string `json:"name"`
-	// The client's version as defined by the client.
-	Version string `json:"version,omitempty"`
 }
 
 // A notebook cell.
@@ -2477,7 +2772,7 @@ type Msg_XInitializeParams_clientInfo struct { // line 7673
 // notebook cell or the cell's text document.
 //
 // @since 3.17.0
-type NotebookCell struct { // line 9598
+type NotebookCell struct {
 	// The cell's kind
 	Kind NotebookCellKind `json:"kind"`
 	// The URI of the cell's text document
@@ -2496,7 +2791,7 @@ type NotebookCell struct { // line 9598
 // array from state S to S'.
 //
 // @since 3.17.0
-type NotebookCellArrayChange struct { // line 9639
+type NotebookCellArrayChange struct {
 	// The start oftest of the cell that changed.
 	Start uint32 `json:"start"`
 	// The deleted cells
@@ -2508,12 +2803,19 @@ type NotebookCellArrayChange struct { // line 9639
 // A notebook cell kind.
 //
 // @since 3.17.0
-type NotebookCellKind uint32 // line 13648
+type NotebookCellKind uint32
+
+// @since 3.18.0
+// @proposed
+type NotebookCellLanguage struct {
+	Language string `json:"language"`
+}
+
 // A notebook cell text document filter denotes a cell text
 // document by different properties.
 //
 // @since 3.17.0
-type NotebookCellTextDocumentFilter struct { // line 10113
+type NotebookCellTextDocumentFilter struct {
 	// A filter that matches against the notebook
 	// containing the notebook cell. If a string
 	// value is provided it matches against the
@@ -2529,7 +2831,7 @@ type NotebookCellTextDocumentFilter struct { // line 10113
 // A notebook document.
 //
 // @since 3.17.0
-type NotebookDocument struct { // line 7354
+type NotebookDocument struct {
 	// The notebook document's uri.
 	URI URI `json:"uri"`
 	// The type of the notebook.
@@ -2546,22 +2848,59 @@ type NotebookDocument struct { // line 7354
 	Cells []NotebookCell `json:"cells"`
 }
 
+// Structural changes to cells in a notebook document.
+//
+// @since 3.18.0
+// @proposed
+type NotebookDocumentCellChangeStructure struct {
+	// The change to the cell array.
+	Array NotebookCellArrayChange `json:"array"`
+	// Additional opened cell text documents.
+	DidOpen []TextDocumentItem `json:"didOpen,omitempty"`
+	// Additional closed cell text documents.
+	DidClose []TextDocumentIdentifier `json:"didClose,omitempty"`
+}
+
+// Cell changes to a notebook document.
+//
+// @since 3.18.0
+// @proposed
+type NotebookDocumentCellChanges struct {
+	// Changes to the cell structure to add or
+	// remove cells.
+	Structure *NotebookDocumentCellChangeStructure `json:"structure,omitempty"`
+	// Changes to notebook cells properties like its
+	// kind, execution summary or metadata.
+	Data []NotebookCell `json:"data,omitempty"`
+	// Changes to the text content of notebook cells.
+	TextContent []NotebookDocumentCellContentChanges `json:"textContent,omitempty"`
+}
+
+// Content changes to a cell in a notebook document.
+//
+// @since 3.18.0
+// @proposed
+type NotebookDocumentCellContentChanges struct {
+	Document VersionedTextDocumentIdentifier  `json:"document"`
+	Changes  []TextDocumentContentChangeEvent `json:"changes"`
+}
+
 // A change event for a notebook document.
 //
 // @since 3.17.0
-type NotebookDocumentChangeEvent struct { // line 7466
+type NotebookDocumentChangeEvent struct {
 	// The changed meta data if any.
 	//
 	// Note: should always be an object literal (e.g. LSPObject)
 	Metadata *LSPObject `json:"metadata,omitempty"`
 	// Changes to cells
-	Cells *PCellsPChange `json:"cells,omitempty"`
+	Cells *NotebookDocumentCellChanges `json:"cells,omitempty"`
 }
 
 // Capabilities specific to the notebook document support.
 //
 // @since 3.17.0
-type NotebookDocumentClientCapabilities struct { // line 10613
+type NotebookDocumentClientCapabilities struct {
 	// Capabilities specific to notebook document synchronization
 	//
 	// @since 3.17.0
@@ -2573,11 +2912,72 @@ type NotebookDocumentClientCapabilities struct { // line 10613
 // against the notebook's URI (same as with documents)
 //
 // @since 3.17.0
-type NotebookDocumentFilter = Msg_NotebookDocumentFilter // (alias) line 14254
+type NotebookDocumentFilter = Or_NotebookDocumentFilter // (alias)
+// A notebook document filter where `notebookType` is required field.
+//
+// @since 3.18.0
+// @proposed
+type NotebookDocumentFilterNotebookType struct {
+	// The type of the enclosing notebook.
+	NotebookType string `json:"notebookType"`
+	// A Uri {@link Uri.scheme scheme}, like `file` or `untitled`.
+	Scheme string `json:"scheme,omitempty"`
+	// A glob pattern.
+	Pattern string `json:"pattern,omitempty"`
+}
+
+// A notebook document filter where `pattern` is required field.
+//
+// @since 3.18.0
+// @proposed
+type NotebookDocumentFilterPattern struct {
+	// The type of the enclosing notebook.
+	NotebookType string `json:"notebookType,omitempty"`
+	// A Uri {@link Uri.scheme scheme}, like `file` or `untitled`.
+	Scheme string `json:"scheme,omitempty"`
+	// A glob pattern.
+	Pattern string `json:"pattern"`
+}
+
+// A notebook document filter where `scheme` is required field.
+//
+// @since 3.18.0
+// @proposed
+type NotebookDocumentFilterScheme struct {
+	// The type of the enclosing notebook.
+	NotebookType string `json:"notebookType,omitempty"`
+	// A Uri {@link Uri.scheme scheme}, like `file` or `untitled`.
+	Scheme string `json:"scheme"`
+	// A glob pattern.
+	Pattern string `json:"pattern,omitempty"`
+}
+
+// @since 3.18.0
+// @proposed
+type NotebookDocumentFilterWithCells struct {
+	// The notebook to be synced If a string
+	// value is provided it matches against the
+	// notebook type. '*' matches every notebook.
+	Notebook *Or_NotebookDocumentFilterWithCells_notebook `json:"notebook,omitempty"`
+	// The cells of the matching notebook to be synced.
+	Cells []NotebookCellLanguage `json:"cells"`
+}
+
+// @since 3.18.0
+// @proposed
+type NotebookDocumentFilterWithNotebook struct {
+	// The notebook to be synced If a string
+	// value is provided it matches against the
+	// notebook type. '*' matches every notebook.
+	Notebook Or_NotebookDocumentFilterWithNotebook_notebook `json:"notebook"`
+	// The cells of the matching notebook to be synced.
+	Cells []NotebookCellLanguage `json:"cells,omitempty"`
+}
+
 // A literal to identify a notebook document in the client.
 //
 // @since 3.17.0
-type NotebookDocumentIdentifier struct { // line 7582
+type NotebookDocumentIdentifier struct {
 	// The notebook document's uri.
 	URI URI `json:"uri"`
 }
@@ -2585,7 +2985,7 @@ type NotebookDocumentIdentifier struct { // line 7582
 // Notebook specific client capabilities.
 //
 // @since 3.17.0
-type NotebookDocumentSyncClientCapabilities struct { // line 12433
+type NotebookDocumentSyncClientCapabilities struct {
 	// Whether implementation supports dynamic registration. If this is
 	// set to `true` the client supports the new
 	// `(TextDocumentRegistrationOptions & StaticRegistrationOptions)`
@@ -2608,9 +3008,9 @@ type NotebookDocumentSyncClientCapabilities struct { // line 12433
 // cell will be synced.
 //
 // @since 3.17.0
-type NotebookDocumentSyncOptions struct { // line 9795
+type NotebookDocumentSyncOptions struct {
 	// The notebooks to be synced
-	NotebookSelector []PNotebookSelectorPNotebookDocumentSync `json:"notebookSelector"`
+	NotebookSelector []Or_NotebookDocumentSyncOptions_notebookSelector_Elem `json:"notebookSelector"`
 	// Whether save notification should be forwarded to
 	// the server. Will only be honored if mode === `notebook`.
 	Save bool `json:"save,omitempty"`
@@ -2619,13 +3019,13 @@ type NotebookDocumentSyncOptions struct { // line 9795
 // Registration options specific to a notebook.
 //
 // @since 3.17.0
-type NotebookDocumentSyncRegistrationOptions struct { // line 9915
+type NotebookDocumentSyncRegistrationOptions struct {
 	NotebookDocumentSyncOptions
 	StaticRegistrationOptions
 }
 
 // A text document identifier to optionally denote a specific version of a text document.
-type OptionalVersionedTextDocumentIdentifier struct { // line 9343
+type OptionalVersionedTextDocumentIdentifier struct {
 	// The version number of this document. If a versioned text document identifier
 	// is sent from the server to the client and the file is not open in the editor
 	// (the server has not received an open notification before) the server can send
@@ -2635,623 +3035,367 @@ type OptionalVersionedTextDocumentIdentifier struct { // line 9343
 	TextDocumentIdentifier
 }
 
-// created for Or [FEditRangePItemDefaults Range]
-type OrFEditRangePItemDefaults struct { // line 4770
-	Value interface{} `json:"value"`
-}
-
-// created for Or [NotebookDocumentFilter string]
-type OrFNotebookPNotebookSelector struct { // line 9812
-	Value interface{} `json:"value"`
-}
-
-// created for Or [Location PLocationMsg_workspace_symbol]
-type OrPLocation_workspace_symbol struct { // line 5521
+// created for Or [Location LocationUriOnly]
+type OrPLocation_workspace_symbol struct {
 	Value interface{} `json:"value"`
 }
 
 // created for Or [[]string string]
-type OrPSection_workspace_didChangeConfiguration struct { // line 4164
+type OrPSection_workspace_didChangeConfiguration struct {
 	Value interface{} `json:"value"`
 }
 
 // created for Or [MarkupContent string]
-type OrPTooltipPLabel struct { // line 7076
+type OrPTooltipPLabel struct {
 	Value interface{} `json:"value"`
 }
 
 // created for Or [MarkupContent string]
-type OrPTooltip_textDocument_inlayHint struct { // line 3700
+type OrPTooltip_textDocument_inlayHint struct {
 	Value interface{} `json:"value"`
 }
 
 // created for Or [int32 string]
-type Or_CancelParams_id struct { // line 6185
+type Or_CancelParams_id struct {
+	Value interface{} `json:"value"`
+}
+
+// created for Or [ClientSemanticTokensRequestFullDelta bool]
+type Or_ClientSemanticTokensRequestOptions_full struct {
+	Value interface{} `json:"value"`
+}
+
+// created for Or [Lit_ClientSemanticTokensRequestOptions_range_Item1 bool]
+type Or_ClientSemanticTokensRequestOptions_range struct {
+	Value interface{} `json:"value"`
+}
+
+// created for Or [EditRangeWithInsertReplace Range]
+type Or_CompletionItemDefaults_editRange struct {
 	Value interface{} `json:"value"`
 }
 
 // created for Or [MarkupContent string]
-type Or_CompletionItem_documentation struct { // line 4583
+type Or_CompletionItem_documentation struct {
 	Value interface{} `json:"value"`
 }
 
 // created for Or [InsertReplaceEdit TextEdit]
-type Or_CompletionItem_textEdit struct { // line 4666
+type Or_CompletionItem_textEdit struct {
 	Value interface{} `json:"value"`
 }
 
 // created for Or [Location []Location]
-type Or_Definition struct { // line 13754
+type Or_Definition struct {
 	Value interface{} `json:"value"`
 }
 
 // created for Or [int32 string]
-type Or_Diagnostic_code struct { // line 8548
+type Or_Diagnostic_code struct {
 	Value interface{} `json:"value"`
 }
 
 // created for Or [RelatedFullDocumentDiagnosticReport RelatedUnchangedDocumentDiagnosticReport]
-type Or_DocumentDiagnosticReport struct { // line 13886
+type Or_DocumentDiagnosticReport struct {
 	Value interface{} `json:"value"`
 }
 
 // created for Or [FullDocumentDiagnosticReport UnchangedDocumentDiagnosticReport]
-type Or_DocumentDiagnosticReportPartialResult_relatedDocuments_Value struct { // line 3823
+type Or_DocumentDiagnosticReportPartialResult_relatedDocuments_Value struct {
 	Value interface{} `json:"value"`
 }
 
 // created for Or [NotebookCellTextDocumentFilter TextDocumentFilter]
-type Or_DocumentFilter struct { // line 14096
+type Or_DocumentFilter struct {
 	Value interface{} `json:"value"`
 }
 
 // created for Or [MarkedString MarkupContent []MarkedString]
-type Or_Hover_contents struct { // line 4892
+type Or_Hover_contents struct {
 	Value interface{} `json:"value"`
 }
 
 // created for Or [[]InlayHintLabelPart string]
-type Or_InlayHint_label struct { // line 3659
+type Or_InlayHint_label struct {
+	Value interface{} `json:"value"`
+}
+
+// created for Or [StringValue string]
+type Or_InlineCompletionItem_insertText struct {
 	Value interface{} `json:"value"`
 }
 
 // created for Or [InlineValueEvaluatableExpression InlineValueText InlineValueVariableLookup]
-type Or_InlineValue struct { // line 13864
+type Or_InlineValue struct {
 	Value interface{} `json:"value"`
 }
 
-// created for Or [Msg_MarkedString string]
-type Or_MarkedString struct { // line 14061
-	Value interface{} `json:"value"`
-}
-
-// created for Or [NotebookDocumentFilter string]
-type Or_NotebookCellTextDocumentFilter_notebook struct { // line 10119
+// created for Or [MarkedStringWithLanguage string]
+type Or_MarkedString struct {
 	Value interface{} `json:"value"`
 }
 
 // created for Or [NotebookDocumentFilter string]
-type Or_NotebookDocumentSyncOptions_notebookSelector_Elem_Item1_notebook struct { // line 9858
+type Or_NotebookCellTextDocumentFilter_notebook struct {
+	Value interface{} `json:"value"`
+}
+
+// created for Or [NotebookDocumentFilterNotebookType NotebookDocumentFilterPattern NotebookDocumentFilterScheme]
+type Or_NotebookDocumentFilter struct {
+	Value interface{} `json:"value"`
+}
+
+// created for Or [NotebookDocumentFilter string]
+type Or_NotebookDocumentFilterWithCells_notebook struct {
+	Value interface{} `json:"value"`
+}
+
+// created for Or [NotebookDocumentFilter string]
+type Or_NotebookDocumentFilterWithNotebook_notebook struct {
+	Value interface{} `json:"value"`
+}
+
+// created for Or [NotebookDocumentFilterWithCells NotebookDocumentFilterWithNotebook]
+type Or_NotebookDocumentSyncOptions_notebookSelector_Elem struct {
 	Value interface{} `json:"value"`
 }
 
 // created for Or [FullDocumentDiagnosticReport UnchangedDocumentDiagnosticReport]
-type Or_RelatedFullDocumentDiagnosticReport_relatedDocuments_Value struct { // line 7169
+type Or_RelatedFullDocumentDiagnosticReport_relatedDocuments_Value struct {
 	Value interface{} `json:"value"`
 }
 
 // created for Or [FullDocumentDiagnosticReport UnchangedDocumentDiagnosticReport]
-type Or_RelatedUnchangedDocumentDiagnosticReport_relatedDocuments_Value struct { // line 7208
+type Or_RelatedUnchangedDocumentDiagnosticReport_relatedDocuments_Value struct {
 	Value interface{} `json:"value"`
 }
 
 // created for Or [URI WorkspaceFolder]
-type Or_RelativePattern_baseUri struct { // line 10742
+type Or_RelativePattern_baseUri struct {
 	Value interface{} `json:"value"`
 }
 
 // created for Or [CodeAction Command]
-type Or_Result_textDocument_codeAction_Item0_Elem struct { // line 1372
+type Or_Result_textDocument_codeAction_Item0_Elem struct {
 	Value interface{} `json:"value"`
 }
 
-// created for Or [FFullPRequests bool]
-type Or_SemanticTokensClientCapabilities_requests_full struct { // line 12198
+// created for Or [CompletionList []CompletionItem]
+type Or_Result_textDocument_completion struct {
 	Value interface{} `json:"value"`
 }
 
-// created for Or [FRangePRequests bool]
-type Or_SemanticTokensClientCapabilities_requests_range struct { // line 12178
+// created for Or [Definition []DefinitionLink]
+type Or_Result_textDocument_definition struct {
 	Value interface{} `json:"value"`
 }
 
-// created for Or [PFullESemanticTokensOptions bool]
-type Or_SemanticTokensOptions_full struct { // line 6580
+// created for Or [InlineCompletionList []InlineCompletionItem]
+type Or_Result_textDocument_inlineCompletion struct {
+	Value interface{} `json:"value"`
+}
+
+// created for Or [SemanticTokensFullDelta bool]
+type Or_SemanticTokensOptions_full struct {
 	Value interface{} `json:"value"`
 }
 
 // created for Or [PRangeESemanticTokensOptions bool]
-type Or_SemanticTokensOptions_range struct { // line 6560
+type Or_SemanticTokensOptions_range struct {
 	Value interface{} `json:"value"`
 }
 
 // created for Or [CallHierarchyOptions CallHierarchyRegistrationOptions bool]
-type Or_ServerCapabilities_callHierarchyProvider struct { // line 8228
+type Or_ServerCapabilities_callHierarchyProvider struct {
 	Value interface{} `json:"value"`
 }
 
 // created for Or [CodeActionOptions bool]
-type Or_ServerCapabilities_codeActionProvider struct { // line 8036
+type Or_ServerCapabilities_codeActionProvider struct {
 	Value interface{} `json:"value"`
 }
 
 // created for Or [DocumentColorOptions DocumentColorRegistrationOptions bool]
-type Or_ServerCapabilities_colorProvider struct { // line 8072
+type Or_ServerCapabilities_colorProvider struct {
 	Value interface{} `json:"value"`
 }
 
 // created for Or [DeclarationOptions DeclarationRegistrationOptions bool]
-type Or_ServerCapabilities_declarationProvider struct { // line 7898
+type Or_ServerCapabilities_declarationProvider struct {
 	Value interface{} `json:"value"`
 }
 
 // created for Or [DefinitionOptions bool]
-type Or_ServerCapabilities_definitionProvider struct { // line 7920
+type Or_ServerCapabilities_definitionProvider struct {
 	Value interface{} `json:"value"`
 }
 
 // created for Or [DiagnosticOptions DiagnosticRegistrationOptions]
-type Or_ServerCapabilities_diagnosticProvider struct { // line 8385
+type Or_ServerCapabilities_diagnosticProvider struct {
 	Value interface{} `json:"value"`
 }
 
 // created for Or [DocumentFormattingOptions bool]
-type Or_ServerCapabilities_documentFormattingProvider struct { // line 8112
+type Or_ServerCapabilities_documentFormattingProvider struct {
 	Value interface{} `json:"value"`
 }
 
 // created for Or [DocumentHighlightOptions bool]
-type Or_ServerCapabilities_documentHighlightProvider struct { // line 8000
+type Or_ServerCapabilities_documentHighlightProvider struct {
 	Value interface{} `json:"value"`
 }
 
 // created for Or [DocumentRangeFormattingOptions bool]
-type Or_ServerCapabilities_documentRangeFormattingProvider struct { // line 8130
+type Or_ServerCapabilities_documentRangeFormattingProvider struct {
 	Value interface{} `json:"value"`
 }
 
 // created for Or [DocumentSymbolOptions bool]
-type Or_ServerCapabilities_documentSymbolProvider struct { // line 8018
+type Or_ServerCapabilities_documentSymbolProvider struct {
 	Value interface{} `json:"value"`
 }
 
 // created for Or [FoldingRangeOptions FoldingRangeRegistrationOptions bool]
-type Or_ServerCapabilities_foldingRangeProvider struct { // line 8175
+type Or_ServerCapabilities_foldingRangeProvider struct {
 	Value interface{} `json:"value"`
 }
 
 // created for Or [HoverOptions bool]
-type Or_ServerCapabilities_hoverProvider struct { // line 7871
+type Or_ServerCapabilities_hoverProvider struct {
 	Value interface{} `json:"value"`
 }
 
 // created for Or [ImplementationOptions ImplementationRegistrationOptions bool]
-type Or_ServerCapabilities_implementationProvider struct { // line 7960
+type Or_ServerCapabilities_implementationProvider struct {
 	Value interface{} `json:"value"`
 }
 
 // created for Or [InlayHintOptions InlayHintRegistrationOptions bool]
-type Or_ServerCapabilities_inlayHintProvider struct { // line 8362
+type Or_ServerCapabilities_inlayHintProvider struct {
+	Value interface{} `json:"value"`
+}
+
+// created for Or [InlineCompletionOptions bool]
+type Or_ServerCapabilities_inlineCompletionProvider struct {
 	Value interface{} `json:"value"`
 }
 
 // created for Or [InlineValueOptions InlineValueRegistrationOptions bool]
-type Or_ServerCapabilities_inlineValueProvider struct { // line 8339
+type Or_ServerCapabilities_inlineValueProvider struct {
 	Value interface{} `json:"value"`
 }
 
 // created for Or [LinkedEditingRangeOptions LinkedEditingRangeRegistrationOptions bool]
-type Or_ServerCapabilities_linkedEditingRangeProvider struct { // line 8251
+type Or_ServerCapabilities_linkedEditingRangeProvider struct {
 	Value interface{} `json:"value"`
 }
 
 // created for Or [MonikerOptions MonikerRegistrationOptions bool]
-type Or_ServerCapabilities_monikerProvider struct { // line 8293
+type Or_ServerCapabilities_monikerProvider struct {
 	Value interface{} `json:"value"`
 }
 
 // created for Or [NotebookDocumentSyncOptions NotebookDocumentSyncRegistrationOptions]
-type Or_ServerCapabilities_notebookDocumentSync struct { // line 7843
+type Or_ServerCapabilities_notebookDocumentSync struct {
 	Value interface{} `json:"value"`
 }
 
 // created for Or [ReferenceOptions bool]
-type Or_ServerCapabilities_referencesProvider struct { // line 7982
+type Or_ServerCapabilities_referencesProvider struct {
 	Value interface{} `json:"value"`
 }
 
 // created for Or [RenameOptions bool]
-type Or_ServerCapabilities_renameProvider struct { // line 8157
+type Or_ServerCapabilities_renameProvider struct {
 	Value interface{} `json:"value"`
 }
 
 // created for Or [SelectionRangeOptions SelectionRangeRegistrationOptions bool]
-type Or_ServerCapabilities_selectionRangeProvider struct { // line 8197
+type Or_ServerCapabilities_selectionRangeProvider struct {
 	Value interface{} `json:"value"`
 }
 
 // created for Or [SemanticTokensOptions SemanticTokensRegistrationOptions]
-type Or_ServerCapabilities_semanticTokensProvider struct { // line 8274
+type Or_ServerCapabilities_semanticTokensProvider struct {
 	Value interface{} `json:"value"`
 }
 
 // created for Or [TextDocumentSyncKind TextDocumentSyncOptions]
-type Or_ServerCapabilities_textDocumentSync struct { // line 7825
+type Or_ServerCapabilities_textDocumentSync struct {
 	Value interface{} `json:"value"`
 }
 
 // created for Or [TypeDefinitionOptions TypeDefinitionRegistrationOptions bool]
-type Or_ServerCapabilities_typeDefinitionProvider struct { // line 7938
+type Or_ServerCapabilities_typeDefinitionProvider struct {
 	Value interface{} `json:"value"`
 }
 
 // created for Or [TypeHierarchyOptions TypeHierarchyRegistrationOptions bool]
-type Or_ServerCapabilities_typeHierarchyProvider struct { // line 8316
+type Or_ServerCapabilities_typeHierarchyProvider struct {
 	Value interface{} `json:"value"`
 }
 
 // created for Or [WorkspaceSymbolOptions bool]
-type Or_ServerCapabilities_workspaceSymbolProvider struct { // line 8094
+type Or_ServerCapabilities_workspaceSymbolProvider struct {
 	Value interface{} `json:"value"`
 }
 
 // created for Or [MarkupContent string]
-type Or_SignatureInformation_documentation struct { // line 8842
+type Or_SignatureInformation_documentation struct {
 	Value interface{} `json:"value"`
 }
 
 // created for Or [AnnotatedTextEdit TextEdit]
-type Or_TextDocumentEdit_edits_Elem struct { // line 6693
+type Or_TextDocumentEdit_edits_Elem struct {
+	Value interface{} `json:"value"`
+}
+
+// created for Or [TextDocumentFilterLanguage TextDocumentFilterPattern TextDocumentFilterScheme]
+type Or_TextDocumentFilter struct {
 	Value interface{} `json:"value"`
 }
 
 // created for Or [SaveOptions bool]
-type Or_TextDocumentSyncOptions_save struct { // line 9778
+type Or_TextDocumentSyncOptions_save struct {
 	Value interface{} `json:"value"`
 }
 
 // created for Or [WorkspaceFullDocumentDiagnosticReport WorkspaceUnchangedDocumentDiagnosticReport]
-type Or_WorkspaceDocumentDiagnosticReport struct { // line 13987
+type Or_WorkspaceDocumentDiagnosticReport struct {
 	Value interface{} `json:"value"`
 }
 
 // created for Or [CreateFile DeleteFile RenameFile TextDocumentEdit]
-type Or_WorkspaceEdit_documentChanges_Elem struct { // line 3220
+type Or_WorkspaceEdit_documentChanges_Elem struct {
 	Value interface{} `json:"value"`
 }
 
 // created for Or [bool string]
-type Or_WorkspaceFoldersServerCapabilities_changeNotifications struct { // line 9948
+type Or_WorkspaceFoldersServerCapabilities_changeNotifications struct {
 	Value interface{} `json:"value"`
 }
 
 // created for Or [Declaration []DeclarationLink]
-type Or_textDocument_declaration struct { // line 249
+type Or_textDocument_declaration struct {
 	Value interface{} `json:"value"`
 }
 
-// created for Literal (Lit_NotebookDocumentChangeEvent_cells)
-type PCellsPChange struct { // line 7481
-	// Changes to the cell structure to add or
-	// remove cells.
-	Structure *FStructurePCells `json:"structure,omitempty"`
-	// Changes to notebook cells properties like its
-	// kind, execution summary or metadata.
-	Data []NotebookCell `json:"data,omitempty"`
-	// Changes to the text content of notebook cells.
-	TextContent []Lit_NotebookDocumentChangeEvent_cells_textContent_Elem `json:"textContent,omitempty"`
-}
-
-// created for Literal (Lit_WorkspaceEditClientCapabilities_changeAnnotationSupport)
-type PChangeAnnotationSupportPWorkspaceEdit struct { // line 10816
-	// Whether the client groups edits with equal labels into tree nodes,
-	// for instance all edits labelled with "Changes in Strings" would
-	// be a tree node.
-	GroupsOnLabel bool `json:"groupsOnLabel,omitempty"`
-}
-
-// created for Literal (Lit_CodeActionClientCapabilities_codeActionLiteralSupport)
-type PCodeActionLiteralSupportPCodeAction struct { // line 11736
-	// The code action kind is support with the following value
-	// set.
-	CodeActionKind FCodeActionKindPCodeActionLiteralSupport `json:"codeActionKind"`
-}
-
-// created for Literal (Lit_CompletionClientCapabilities_completionItemKind)
-type PCompletionItemKindPCompletion struct { // line 11334
-	// The completion item kind values the client supports. When this
-	// property exists the client also guarantees that it will
-	// handle values outside its set gracefully and falls back
-	// to a default value when unknown.
-	//
-	// If this property is not present the client only supports
-	// the completion items kinds from `Text` to `Reference` as defined in
-	// the initial version of the protocol.
-	ValueSet []CompletionItemKind `json:"valueSet,omitempty"`
-}
-
-// created for Literal (Lit_CompletionClientCapabilities_completionItem)
-type PCompletionItemPCompletion struct { // line 11183
-	// Client supports snippets as insert text.
-	//
-	// A snippet can define tab stops and placeholders with `$1`, `$2`
-	// and `${3:foo}`. `$0` defines the final tab stop, it defaults to
-	// the end of the snippet. Placeholders with equal identifiers are linked,
-	// that is typing in one will update others too.
-	SnippetSupport bool `json:"snippetSupport,omitempty"`
-	// Client supports commit characters on a completion item.
-	CommitCharactersSupport bool `json:"commitCharactersSupport,omitempty"`
-	// Client supports the following content formats for the documentation
-	// property. The order describes the preferred format of the client.
-	DocumentationFormat []MarkupKind `json:"documentationFormat,omitempty"`
-	// Client supports the deprecated property on a completion item.
-	DeprecatedSupport bool `json:"deprecatedSupport,omitempty"`
-	// Client supports the preselect property on a completion item.
-	PreselectSupport bool `json:"preselectSupport,omitempty"`
-	// Client supports the tag property on a completion item. Clients supporting
-	// tags have to handle unknown tags gracefully. Clients especially need to
-	// preserve unknown tags when sending a completion item back to the server in
-	// a resolve call.
-	//
-	// @since 3.15.0
-	TagSupport FTagSupportPCompletionItem `json:"tagSupport"`
-	// Client support insert replace edit to control different behavior if a
-	// completion item is inserted in the text or should replace text.
-	//
-	// @since 3.16.0
-	InsertReplaceSupport bool `json:"insertReplaceSupport,omitempty"`
-	// Indicates which properties a client can resolve lazily on a completion
-	// item. Before version 3.16.0 only the predefined properties `documentation`
-	// and `details` could be resolved lazily.
-	//
-	// @since 3.16.0
-	ResolveSupport *FResolveSupportPCompletionItem `json:"resolveSupport,omitempty"`
-	// The client supports the `insertTextMode` property on
-	// a completion item to override the whitespace handling mode
-	// as defined by the client (see `insertTextMode`).
-	//
-	// @since 3.16.0
-	InsertTextModeSupport *FInsertTextModeSupportPCompletionItem `json:"insertTextModeSupport,omitempty"`
-	// The client has support for completion item label
-	// details (see also `CompletionItemLabelDetails`).
-	//
-	// @since 3.17.0
-	LabelDetailsSupport bool `json:"labelDetailsSupport,omitempty"`
-}
-
-// created for Literal (Lit_CompletionOptions_completionItem)
-type PCompletionItemPCompletionProvider struct { // line 8747
-	// The server has support for completion item label
-	// details (see also `CompletionItemLabelDetails`) when
-	// receiving a completion item in a resolve call.
-	//
-	// @since 3.17.0
-	LabelDetailsSupport bool `json:"labelDetailsSupport,omitempty"`
-}
-
-// created for Literal (Lit_CompletionClientCapabilities_completionList)
-type PCompletionListPCompletion struct { // line 11376
-	// The client supports the following itemDefaults on
-	// a completion list.
-	//
-	// The value lists the supported property names of the
-	// `CompletionList.itemDefaults` object. If omitted
-	// no properties are supported.
-	//
-	// @since 3.17.0
-	ItemDefaults []string `json:"itemDefaults,omitempty"`
-}
-
-// created for Literal (Lit_CodeAction_disabled)
-type PDisabledMsg_textDocument_codeAction struct { // line 5427
-	// Human readable description of why the code action is currently disabled.
-	//
-	// This is displayed in the code actions UI.
-	Reason string `json:"reason"`
-}
-
-// created for Literal (Lit_FoldingRangeClientCapabilities_foldingRangeKind)
-type PFoldingRangeKindPFoldingRange struct { // line 12011
-	// The folding range kind values the client supports. When this
-	// property exists the client also guarantees that it will
-	// handle values outside its set gracefully and falls back
-	// to a default value when unknown.
-	ValueSet []FoldingRangeKind `json:"valueSet,omitempty"`
-}
-
-// created for Literal (Lit_FoldingRangeClientCapabilities_foldingRange)
-type PFoldingRangePFoldingRange struct { // line 12036
-	// If set, the client signals that it supports setting collapsedText on
-	// folding ranges to display custom labels instead of the default text.
-	//
-	// @since 3.17.0
-	CollapsedText bool `json:"collapsedText,omitempty"`
-}
-
-// created for Literal (Lit_SemanticTokensOptions_full_Item1)
-type PFullESemanticTokensOptions struct { // line 6587
-	// The server supports deltas for full documents.
-	Delta bool `json:"delta"`
-}
-
-// created for Literal (Lit_CompletionList_itemDefaults)
-type PItemDefaultsMsg_textDocument_completion struct { // line 4751
-	// A default commit character set.
-	//
-	// @since 3.17.0
-	CommitCharacters []string `json:"commitCharacters,omitempty"`
-	// A default edit range.
-	//
-	// @since 3.17.0
-	EditRange *OrFEditRangePItemDefaults `json:"editRange,omitempty"`
-	// A default insert text format.
-	//
-	// @since 3.17.0
-	InsertTextFormat *InsertTextFormat `json:"insertTextFormat,omitempty"`
-	// A default insert text mode.
-	//
-	// @since 3.17.0
-	InsertTextMode *InsertTextMode `json:"insertTextMode,omitempty"`
-	// A default data value.
-	//
-	// @since 3.17.0
-	Data interface{} `json:"data,omitempty"`
-}
-
-// created for Literal (Lit_WorkspaceSymbol_location_Item1)
-type PLocationMsg_workspace_symbol struct { // line 5528
-	URI DocumentURI `json:"uri"`
-}
-
-// created for Literal (Lit_ShowMessageRequestClientCapabilities_messageActionItem)
-type PMessageActionItemPShowMessage struct { // line 12464
-	// Whether the client supports additional attributes which
-	// are preserved and send back to the server in the
-	// request's response.
-	AdditionalPropertiesSupport bool `json:"additionalPropertiesSupport,omitempty"`
-}
-
-// created for Literal (Lit_NotebookDocumentSyncOptions_notebookSelector_Elem_Item0)
-type PNotebookSelectorPNotebookDocumentSync struct { // line 9806
-	// The notebook to be synced If a string
-	// value is provided it matches against the
-	// notebook type. '*' matches every notebook.
-	Notebook OrFNotebookPNotebookSelector `json:"notebook"`
-	// The cells of the matching notebook to be synced.
-	Cells []Lit_NotebookDocumentSyncOptions_notebookSelector_Elem_Item0_cells_Elem `json:"cells,omitempty"`
-}
-
 // created for Literal (Lit_SemanticTokensOptions_range_Item1)
-type PRangeESemanticTokensOptions struct { // line 6567
-}
-
-// created for Literal (Lit_SemanticTokensClientCapabilities_requests)
-type PRequestsPSemanticTokens struct { // line 12172
-	// The client will send the `textDocument/semanticTokens/range` request if
-	// the server provides a corresponding handler.
-	Range Or_SemanticTokensClientCapabilities_requests_range `json:"range"`
-	// The client will send the `textDocument/semanticTokens/full` request if
-	// the server provides a corresponding handler.
-	Full Or_SemanticTokensClientCapabilities_requests_full `json:"full"`
-}
-
-// created for Literal (Lit_CodeActionClientCapabilities_resolveSupport)
-type PResolveSupportPCodeAction struct { // line 11801
-	// The properties that a client can resolve lazily.
-	Properties []string `json:"properties"`
-}
-
-// created for Literal (Lit_InlayHintClientCapabilities_resolveSupport)
-type PResolveSupportPInlayHint struct { // line 12384
-	// The properties that a client can resolve lazily.
-	Properties []string `json:"properties"`
-}
-
-// created for Literal (Lit_WorkspaceSymbolClientCapabilities_resolveSupport)
-type PResolveSupportPSymbol struct { // line 10938
-	// The properties that a client can resolve lazily. Usually
-	// `location.range`
-	Properties []string `json:"properties"`
-}
-
-// created for Literal (Lit_InitializeResult_serverInfo)
-type PServerInfoMsg_initialize struct { // line 4096
-	// The name of the server as defined by the server.
-	Name string `json:"name"`
-	// The server's version as defined by the server.
-	Version string `json:"version,omitempty"`
-}
-
-// created for Literal (Lit_SignatureHelpClientCapabilities_signatureInformation)
-type PSignatureInformationPSignatureHelp struct { // line 11443
-	// Client supports the following content formats for the documentation
-	// property. The order describes the preferred format of the client.
-	DocumentationFormat []MarkupKind `json:"documentationFormat,omitempty"`
-	// Client capabilities specific to parameter information.
-	ParameterInformation *FParameterInformationPSignatureInformation `json:"parameterInformation,omitempty"`
-	// The client supports the `activeParameter` property on `SignatureInformation`
-	// literal.
-	//
-	// @since 3.16.0
-	ActiveParameterSupport bool `json:"activeParameterSupport,omitempty"`
-}
-
-// created for Literal (Lit_GeneralClientCapabilities_staleRequestSupport)
-type PStaleRequestSupportPGeneral struct { // line 10670
-	// The client will actively cancel the request.
-	Cancel bool `json:"cancel"`
-	// The list of requests for which the client
-	// will retry the request if it receives a
-	// response with error code `ContentModified`
-	RetryOnContentModified []string `json:"retryOnContentModified"`
-}
-
-// created for Literal (Lit_DocumentSymbolClientCapabilities_symbolKind)
-type PSymbolKindPDocumentSymbol struct { // line 11654
-	// The symbol kind values the client supports. When this
-	// property exists the client also guarantees that it will
-	// handle values outside its set gracefully and falls back
-	// to a default value when unknown.
-	//
-	// If this property is not present the client only supports
-	// the symbol kinds from `File` to `Array` as defined in
-	// the initial version of the protocol.
-	ValueSet []SymbolKind `json:"valueSet,omitempty"`
-}
-
-// created for Literal (Lit_WorkspaceSymbolClientCapabilities_symbolKind)
-type PSymbolKindPSymbol struct { // line 10890
-	// The symbol kind values the client supports. When this
-	// property exists the client also guarantees that it will
-	// handle values outside its set gracefully and falls back
-	// to a default value when unknown.
-	//
-	// If this property is not present the client only supports
-	// the symbol kinds from `File` to `Array` as defined in
-	// the initial version of the protocol.
-	ValueSet []SymbolKind `json:"valueSet,omitempty"`
-}
-
-// created for Literal (Lit_DocumentSymbolClientCapabilities_tagSupport)
-type PTagSupportPDocumentSymbol struct { // line 11687
-	// The tags supported by the client.
-	ValueSet []SymbolTag `json:"valueSet"`
-}
-
-// created for Literal (Lit_PublishDiagnosticsClientCapabilities_tagSupport)
-type PTagSupportPPublishDiagnostics struct { // line 12087
-	// The tags supported by the client.
-	ValueSet []DiagnosticTag `json:"valueSet"`
-}
-
-// created for Literal (Lit_WorkspaceSymbolClientCapabilities_tagSupport)
-type PTagSupportPSymbol struct { // line 10914
-	// The tags supported by the client.
-	ValueSet []SymbolTag `json:"valueSet"`
+type PRangeESemanticTokensOptions struct {
 }
 
 // The parameters of a configuration request.
-type ParamConfiguration struct { // line 2199
+type ParamConfiguration struct {
 	Items []ConfigurationItem `json:"items"`
 }
-type ParamInitialize struct { // line 4068
+type ParamInitialize struct {
 	XInitializeParams
 	WorkspaceFoldersInitializeParams
 }
 
 // Represents a parameter of a callable-signature. A parameter can
 // have a label and a doc-comment.
-type ParameterInformation struct { // line 10063
+type ParameterInformation struct {
 	// The label of this parameter information.
 	//
 	// Either a string or an inclusive start and exclusive end offsets within its containing
@@ -3265,7 +3409,7 @@ type ParameterInformation struct { // line 10063
 	// in the UI but can be omitted.
 	Documentation string `json:"documentation,omitempty"`
 }
-type PartialResultParams struct { // line 6258
+type PartialResultParams struct {
 	// An optional token that a server can use to report partial results (e.g. streaming) to
 	// the client.
 	PartialResultToken *ProgressToken `json:"partialResultToken,omitempty"`
@@ -3281,7 +3425,7 @@ type PartialResultParams struct { // line 6258
 //   - `[!...]` to negate a range of characters to match in a path segment (e.g., `example.[!0-9]` to match on `example.a`, `example.b`, but not `example.0`)
 //
 // @since 3.17.0
-type Pattern = string // (alias) line 14363
+type Pattern = string // (alias)
 // Position in a text document expressed as zero-based line and character
 // offset. Prior to 3.17 the offsets were always based on a UTF-16 string
 // representation. So a string of the form `a𐐀b` the character offset of the
@@ -3289,14 +3433,14 @@ type Pattern = string // (alias) line 14363
 // offset of b is 3 since `𐐀` is represented using two code units in UTF-16.
 // Since 3.17 clients and servers can agree on a different string encoding
 // representation (e.g. UTF-8). The client announces it's supported encoding
-// via the client capability [`general.positionEncodings`](#clientCapabilities).
+// via the client capability [`general.positionEncodings`](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#clientCapabilities).
 // The value is an array of position encodings the client supports, with
 // decreasing preference (e.g. the encoding at index `0` is the most preferred
 // one). To stay backwards compatible the only mandatory encoding is UTF-16
 // represented via the string `utf-16`. The server can pick one of the
 // encodings offered by the client and signals that encoding back to the
 // client via the initialize result's property
-// [`capabilities.positionEncoding`](#serverCapabilities). If the string value
+// [`capabilities.positionEncoding`](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#serverCapabilities). If the string value
 // `utf-16` is missing from the client's capability `general.positionEncodings`
 // servers can safely assume that the client supports UTF-16. If the server
 // omits the position encoding in its initialize result the encoding defaults
@@ -3309,7 +3453,7 @@ type Pattern = string // (alias) line 14363
 // that denotes `\r|\n` or `\n|` where `|` represents the character offset.
 //
 // @since 3.17.0 - support for negotiated position encoding.
-type Position struct { // line 6501
+type Position struct {
 	// Line position in a document (zero-based).
 	//
 	// If a line number is greater than the number of lines in a document, it defaults back to the number of lines in the document.
@@ -3328,18 +3472,31 @@ type Position struct { // line 6501
 // A set of predefined position encoding kinds.
 //
 // @since 3.17.0
-type PositionEncodingKind string             // line 13427
-type PrepareRename2Gn = Msg_PrepareRename2Gn // (alias) line 13927
-type PrepareRenameParams struct {            // line 5925
+type PositionEncodingKind string
+
+// @since 3.18.0
+// @proposed
+type PrepareRenameDefaultBehavior struct {
+	DefaultBehavior bool `json:"defaultBehavior"`
+}
+type PrepareRenameParams struct {
 	TextDocumentPositionParams
 	WorkDoneProgressParams
 }
-type PrepareRenameResult = Msg_PrepareRename2Gn // (alias) line 13927
-type PrepareSupportDefaultBehavior uint32       // line 13722
+
+// @since 3.18.0
+// @proposed
+type PrepareRenamePlaceholder struct {
+	Range       Range  `json:"range"`
+	Placeholder string `json:"placeholder"`
+}
+type PrepareRenameResult = PrepareRenamePlaceholder // (alias)
+type PrepareSupportDefaultBehavior uint32
+
 // A previous result id in a workspace pull request.
 //
 // @since 3.17.0
-type PreviousResultID struct { // line 7331
+type PreviousResultID struct {
 	// The URI for which the client knowns a
 	// result id.
 	URI DocumentURI `json:"uri"`
@@ -3350,29 +3507,29 @@ type PreviousResultID struct { // line 7331
 // A previous result id in a workspace pull request.
 //
 // @since 3.17.0
-type PreviousResultId struct { // line 7331
+type PreviousResultId struct {
 	// The URI for which the client knowns a
 	// result id.
 	URI DocumentURI `json:"uri"`
 	// The value of the previous result id.
 	Value string `json:"value"`
 }
-type ProgressParams struct { // line 6201
+type ProgressParams struct {
 	// The progress token provided by the client or server.
 	Token ProgressToken `json:"token"`
 	// The progress data.
 	Value interface{} `json:"value"`
 }
-type ProgressToken = interface{} // (alias) line 13960
+type ProgressToken = interface{} // (alias)
 // The publish diagnostic client capabilities.
-type PublishDiagnosticsClientCapabilities struct { // line 12072
+type PublishDiagnosticsClientCapabilities struct {
 	// Whether the clients accepts diagnostics with related information.
 	RelatedInformation bool `json:"relatedInformation,omitempty"`
 	// Client supports the tag property to provide meta data about a diagnostic.
 	// Clients supporting tags have to handle unknown tags gracefully.
 	//
 	// @since 3.15.0
-	TagSupport *PTagSupportPPublishDiagnostics `json:"tagSupport,omitempty"`
+	TagSupport *ClientDiagnosticsTagOptions `json:"tagSupport,omitempty"`
 	// Whether the client interprets the version property of the
 	// `textDocument/publishDiagnostics` notification's parameter.
 	//
@@ -3391,7 +3548,7 @@ type PublishDiagnosticsClientCapabilities struct { // line 12072
 }
 
 // The publish diagnostic notification's parameters.
-type PublishDiagnosticsParams struct { // line 4462
+type PublishDiagnosticsParams struct {
 	// The URI for which diagnostic information is reported.
 	URI DocumentURI `json:"uri"`
 	// Optional the version number of the document the diagnostics are published for.
@@ -3415,7 +3572,7 @@ type PublishDiagnosticsParams struct { // line 4462
 //	}
 //
 // ```
-type Range struct { // line 6311
+type Range struct {
 	// The range's start position.
 	Start Position `json:"start"`
 	// The range's end position.
@@ -3423,25 +3580,25 @@ type Range struct { // line 6311
 }
 
 // Client Capabilities for a {@link ReferencesRequest}.
-type ReferenceClientCapabilities struct { // line 11609
+type ReferenceClientCapabilities struct {
 	// Whether references supports dynamic registration.
 	DynamicRegistration bool `json:"dynamicRegistration,omitempty"`
 }
 
 // Value-object that contains additional information when
 // requesting references.
-type ReferenceContext struct { // line 8930
+type ReferenceContext struct {
 	// Include the declaration of the current symbol.
 	IncludeDeclaration bool `json:"includeDeclaration"`
 }
 
 // Reference options.
-type ReferenceOptions struct { // line 8944
+type ReferenceOptions struct {
 	WorkDoneProgressOptions
 }
 
 // Parameters for a {@link ReferencesRequest}.
-type ReferenceParams struct { // line 5054
+type ReferenceParams struct {
 	Context ReferenceContext `json:"context"`
 	TextDocumentPositionParams
 	WorkDoneProgressParams
@@ -3449,13 +3606,13 @@ type ReferenceParams struct { // line 5054
 }
 
 // Registration options for a {@link ReferencesRequest}.
-type ReferenceRegistrationOptions struct { // line 5083
+type ReferenceRegistrationOptions struct {
 	TextDocumentRegistrationOptions
 	ReferenceOptions
 }
 
-// General parameters to to register for an notification or to register a provider.
-type Registration struct { // line 7597
+// General parameters to register for a notification or to register a provider.
+type Registration struct {
 	// The id used to register the request. The id can be used to deregister
 	// the request again.
 	ID string `json:"id"`
@@ -3464,14 +3621,14 @@ type Registration struct { // line 7597
 	// Options necessary for the registration.
 	RegisterOptions interface{} `json:"registerOptions,omitempty"`
 }
-type RegistrationParams struct { // line 4038
+type RegistrationParams struct {
 	Registrations []Registration `json:"registrations"`
 }
 
 // Client capabilities specific to regular expressions.
 //
 // @since 3.16.0
-type RegularExpressionsClientCapabilities struct { // line 12500
+type RegularExpressionsClientCapabilities struct {
 	// The engine's name.
 	Engine string `json:"engine"`
 	// The engine's version.
@@ -3481,7 +3638,7 @@ type RegularExpressionsClientCapabilities struct { // line 12500
 // A full diagnostic report with a set of related documents.
 //
 // @since 3.17.0
-type RelatedFullDocumentDiagnosticReport struct { // line 7157
+type RelatedFullDocumentDiagnosticReport struct {
 	// Diagnostics of related documents. This information is useful
 	// in programming languages where code in a file A can generate
 	// diagnostics in a file B which A depends on. An example of
@@ -3496,7 +3653,7 @@ type RelatedFullDocumentDiagnosticReport struct { // line 7157
 // An unchanged diagnostic report with a set of related documents.
 //
 // @since 3.17.0
-type RelatedUnchangedDocumentDiagnosticReport struct { // line 7196
+type RelatedUnchangedDocumentDiagnosticReport struct {
 	// Diagnostics of related documents. This information is useful
 	// in programming languages where code in a file A can generate
 	// diagnostics in a file B which A depends on. An example of
@@ -3513,14 +3670,14 @@ type RelatedUnchangedDocumentDiagnosticReport struct { // line 7196
 // folder root, but it can be another absolute URI as well.
 //
 // @since 3.17.0
-type RelativePattern struct { // line 10736
+type RelativePattern struct {
 	// A workspace folder or a base URI to which this pattern will be matched
 	// against relatively.
 	BaseURI Or_RelativePattern_baseUri `json:"baseUri"`
 	// The actual glob pattern;
 	Pattern Pattern `json:"pattern"`
 }
-type RenameClientCapabilities struct { // line 11934
+type RenameClientCapabilities struct {
 	// Whether rename supports dynamic registration.
 	DynamicRegistration bool `json:"dynamicRegistration,omitempty"`
 	// Client supports testing for validity of rename operations
@@ -3546,7 +3703,7 @@ type RenameClientCapabilities struct { // line 11934
 }
 
 // Rename file operation
-type RenameFile struct { // line 6749
+type RenameFile struct {
 	// A rename
 	Kind string `json:"kind"`
 	// The old (existing) location.
@@ -3559,7 +3716,7 @@ type RenameFile struct { // line 6749
 }
 
 // Rename file options
-type RenameFileOptions struct { // line 9441
+type RenameFileOptions struct {
 	// Overwrite target if existing. Overwrite wins over `ignoreIfExists`
 	Overwrite bool `json:"overwrite,omitempty"`
 	// Ignores if target exists.
@@ -3570,14 +3727,14 @@ type RenameFileOptions struct { // line 9441
 // files.
 //
 // @since 3.16.0
-type RenameFilesParams struct { // line 3282
+type RenameFilesParams struct {
 	// An array of all files/folders renamed in this operation. When a folder is renamed, only
 	// the folder will be included, and not its children.
 	Files []FileRename `json:"files"`
 }
 
 // Provider options for a {@link RenameRequest}.
-type RenameOptions struct { // line 9269
+type RenameOptions struct {
 	// Renames should be checked and tested before being executed.
 	//
 	// @since version 3.12.0
@@ -3586,7 +3743,7 @@ type RenameOptions struct { // line 9269
 }
 
 // The parameters of a {@link RenameRequest}.
-type RenameParams struct { // line 5874
+type RenameParams struct {
 	// The document to rename.
 	TextDocument TextDocumentIdentifier `json:"textDocument"`
 	// The position at which this request was sent.
@@ -3599,13 +3756,13 @@ type RenameParams struct { // line 5874
 }
 
 // Registration options for a {@link RenameRequest}.
-type RenameRegistrationOptions struct { // line 5910
+type RenameRegistrationOptions struct {
 	TextDocumentRegistrationOptions
 	RenameOptions
 }
 
 // A generic resource operation.
-type ResourceOperation struct { // line 9393
+type ResourceOperation struct {
 	// The resource operation kind.
 	Kind string `json:"kind"`
 	// An optional annotation identifier describing the operation.
@@ -3613,33 +3770,45 @@ type ResourceOperation struct { // line 9393
 	// @since 3.16.0
 	AnnotationID *ChangeAnnotationIdentifier `json:"annotationId,omitempty"`
 }
-type ResourceOperationKind string // line 13669
+type ResourceOperationKind string
+
 // Save options.
-type SaveOptions struct { // line 8465
+type SaveOptions struct {
 	// The client is supposed to include the content on save.
 	IncludeText bool `json:"includeText,omitempty"`
 }
 
+// Describes the currently selected completion item.
+//
+// @since 3.18.0
+// @proposed
+type SelectedCompletionInfo struct {
+	// The range that will be replaced if this completion item is accepted.
+	Range Range `json:"range"`
+	// The text the range will be replaced with if this completion is accepted.
+	Text string `json:"text"`
+}
+
 // A selection range represents a part of a selection hierarchy. A selection range
 // may have a parent selection range that contains it.
-type SelectionRange struct { // line 2569
+type SelectionRange struct {
 	// The {@link Range range} of this selection range.
 	Range Range `json:"range"`
 	// The parent selection range containing this range. Therefore `parent.range` must contain `this.range`.
 	Parent *SelectionRange `json:"parent,omitempty"`
 }
-type SelectionRangeClientCapabilities struct { // line 12058
+type SelectionRangeClientCapabilities struct {
 	// Whether implementation supports dynamic registration for selection range providers. If this is set to `true`
 	// the client supports the new `SelectionRangeRegistrationOptions` return value for the corresponding server
 	// capability as well.
 	DynamicRegistration bool `json:"dynamicRegistration,omitempty"`
 }
-type SelectionRangeOptions struct { // line 6524
+type SelectionRangeOptions struct {
 	WorkDoneProgressOptions
 }
 
 // A parameter literal used in selection range requests.
-type SelectionRangeParams struct { // line 2534
+type SelectionRangeParams struct {
 	// The text document.
 	TextDocument TextDocumentIdentifier `json:"textDocument"`
 	// The positions inside the text document.
@@ -3647,7 +3816,7 @@ type SelectionRangeParams struct { // line 2534
 	WorkDoneProgressParams
 	PartialResultParams
 }
-type SelectionRangeRegistrationOptions struct { // line 2592
+type SelectionRangeRegistrationOptions struct {
 	SelectionRangeOptions
 	TextDocumentRegistrationOptions
 	StaticRegistrationOptions
@@ -3658,15 +3827,17 @@ type SelectionRangeRegistrationOptions struct { // line 2592
 // corresponding client capabilities.
 //
 // @since 3.16.0
-type SemanticTokenModifiers string // line 12670
+type SemanticTokenModifiers string
+
 // A set of predefined token types. This set is not fixed
 // an clients can specify additional token types via the
 // corresponding client capabilities.
 //
 // @since 3.16.0
-type SemanticTokenTypes string // line 12563
+type SemanticTokenTypes string
+
 // @since 3.16.0
-type SemanticTokens struct { // line 2880
+type SemanticTokens struct {
 	// An optional result id. If provided and clients support delta updating
 	// the client will include the result id in the next semantic token request.
 	// A server can then instead of computing all semantic tokens again simply
@@ -3677,7 +3848,7 @@ type SemanticTokens struct { // line 2880
 }
 
 // @since 3.16.0
-type SemanticTokensClientCapabilities struct { // line 12157
+type SemanticTokensClientCapabilities struct {
 	// Whether implementation supports dynamic registration. If this is set to `true`
 	// the client supports the new `(TextDocumentRegistrationOptions & StaticRegistrationOptions)`
 	// return value for the corresponding server capability as well.
@@ -3690,7 +3861,7 @@ type SemanticTokensClientCapabilities struct { // line 12157
 	// `request.range` are both set to true but the server only provides a
 	// range provider the client might not render a minimap correctly or might
 	// even decide to not show any semantic tokens at all.
-	Requests PRequestsPSemanticTokens `json:"requests"`
+	Requests ClientSemanticTokensRequestOptions `json:"requests"`
 	// The token types that the client supports.
 	TokenTypes []string `json:"tokenTypes"`
 	// The token modifiers that the client supports.
@@ -3722,14 +3893,14 @@ type SemanticTokensClientCapabilities struct { // line 12157
 }
 
 // @since 3.16.0
-type SemanticTokensDelta struct { // line 2979
+type SemanticTokensDelta struct {
 	ResultID string `json:"resultId,omitempty"`
 	// The semantic token edits to transform a previous result into a new result.
 	Edits []SemanticTokensEdit `json:"edits"`
 }
 
 // @since 3.16.0
-type SemanticTokensDeltaParams struct { // line 2946
+type SemanticTokensDeltaParams struct {
 	// The text document.
 	TextDocument TextDocumentIdentifier `json:"textDocument"`
 	// The result id of a previous response. The result Id can either point to a full response
@@ -3740,12 +3911,12 @@ type SemanticTokensDeltaParams struct { // line 2946
 }
 
 // @since 3.16.0
-type SemanticTokensDeltaPartialResult struct { // line 3005
+type SemanticTokensDeltaPartialResult struct {
 	Edits []SemanticTokensEdit `json:"edits"`
 }
 
 // @since 3.16.0
-type SemanticTokensEdit struct { // line 6617
+type SemanticTokensEdit struct {
 	// The start offset of the edit.
 	Start uint32 `json:"start"`
 	// The count of elements to remove.
@@ -3754,8 +3925,17 @@ type SemanticTokensEdit struct { // line 6617
 	Data []uint32 `json:"data,omitempty"`
 }
 
+// Semantic tokens options to support deltas for full documents
+//
+// @since 3.18.0
+// @proposed
+type SemanticTokensFullDelta struct {
+	// The server supports deltas for full documents.
+	Delta bool `json:"delta,omitempty"`
+}
+
 // @since 3.16.0
-type SemanticTokensLegend struct { // line 9314
+type SemanticTokensLegend struct {
 	// The token types a server uses.
 	TokenTypes []string `json:"tokenTypes"`
 	// The token modifiers a server uses.
@@ -3763,7 +3943,7 @@ type SemanticTokensLegend struct { // line 9314
 }
 
 // @since 3.16.0
-type SemanticTokensOptions struct { // line 6546
+type SemanticTokensOptions struct {
 	// The legend used by the server
 	Legend SemanticTokensLegend `json:"legend"`
 	// Server supports providing semantic tokens for a specific range
@@ -3775,7 +3955,7 @@ type SemanticTokensOptions struct { // line 6546
 }
 
 // @since 3.16.0
-type SemanticTokensParams struct { // line 2855
+type SemanticTokensParams struct {
 	// The text document.
 	TextDocument TextDocumentIdentifier `json:"textDocument"`
 	WorkDoneProgressParams
@@ -3783,12 +3963,12 @@ type SemanticTokensParams struct { // line 2855
 }
 
 // @since 3.16.0
-type SemanticTokensPartialResult struct { // line 2907
+type SemanticTokensPartialResult struct {
 	Data []uint32 `json:"data"`
 }
 
 // @since 3.16.0
-type SemanticTokensRangeParams struct { // line 3022
+type SemanticTokensRangeParams struct {
 	// The text document.
 	TextDocument TextDocumentIdentifier `json:"textDocument"`
 	// The range the semantic tokens are requested for.
@@ -3798,14 +3978,14 @@ type SemanticTokensRangeParams struct { // line 3022
 }
 
 // @since 3.16.0
-type SemanticTokensRegistrationOptions struct { // line 2924
+type SemanticTokensRegistrationOptions struct {
 	TextDocumentRegistrationOptions
 	SemanticTokensOptions
 	StaticRegistrationOptions
 }
 
 // @since 3.16.0
-type SemanticTokensWorkspaceClientCapabilities struct { // line 10977
+type SemanticTokensWorkspaceClientCapabilities struct {
 	// Whether the client implementation supports a refresh request sent from
 	// the server to the client.
 	//
@@ -3818,7 +3998,7 @@ type SemanticTokensWorkspaceClientCapabilities struct { // line 10977
 
 // Defines the capabilities provided by a language
 // server.
-type ServerCapabilities struct { // line 7809
+type ServerCapabilities struct {
 	// The position encoding the server picked from the encodings offered
 	// by the client via the client capability `general.positionEncodings`.
 	//
@@ -3917,32 +4097,60 @@ type ServerCapabilities struct { // line 7809
 	//
 	// @since 3.17.0
 	DiagnosticProvider *Or_ServerCapabilities_diagnosticProvider `json:"diagnosticProvider,omitempty"`
+	// Inline completion options used during static registration.
+	//
+	// @since 3.18.0
+	// @proposed
+	InlineCompletionProvider *Or_ServerCapabilities_inlineCompletionProvider `json:"inlineCompletionProvider,omitempty"`
 	// Workspace specific server capabilities.
-	Workspace *Workspace6Gn `json:"workspace,omitempty"`
+	Workspace *WorkspaceOptions `json:"workspace,omitempty"`
 	// Experimental server capabilities.
 	Experimental interface{} `json:"experimental,omitempty"`
 }
-type SetTraceParams struct { // line 6147
+
+// @since 3.18.0
+// @proposed
+type ServerCompletionItemOptions struct {
+	// The server has support for completion item label
+	// details (see also `CompletionItemLabelDetails`) when
+	// receiving a completion item in a resolve call.
+	//
+	// @since 3.17.0
+	LabelDetailsSupport bool `json:"labelDetailsSupport,omitempty"`
+}
+
+// Information about the server
+//
+// @since 3.15.0
+// @since 3.18.0 ServerInfo type name added.
+// @proposed
+type ServerInfo struct {
+	// The name of the server as defined by the server.
+	Name string `json:"name"`
+	// The server's version as defined by the server.
+	Version string `json:"version,omitempty"`
+}
+type SetTraceParams struct {
 	Value TraceValues `json:"value"`
 }
 
 // Client capabilities for the showDocument request.
 //
 // @since 3.16.0
-type ShowDocumentClientCapabilities struct { // line 12485
+type ShowDocumentClientCapabilities struct {
 	// The client has support for the showDocument
 	// request.
 	Support bool `json:"support"`
 }
 
-// Params to show a document.
+// Params to show a resource in the UI.
 //
 // @since 3.16.0
-type ShowDocumentParams struct { // line 3055
-	// The document uri to show.
+type ShowDocumentParams struct {
+	// The uri to show.
 	URI URI `json:"uri"`
 	// Indicates to show the resource in an external program.
-	// To show for example `https://code.visualstudio.com/`
+	// To show, for example, `https://code.visualstudio.com/`
 	// in the default WEB browser set `external` to `true`.
 	External bool `json:"external,omitempty"`
 	// An optional property to indicate whether the editor
@@ -3960,13 +4168,13 @@ type ShowDocumentParams struct { // line 3055
 // The result of a showDocument request.
 //
 // @since 3.16.0
-type ShowDocumentResult struct { // line 3097
+type ShowDocumentResult struct {
 	// A boolean indicating if the show was successful.
 	Success bool `json:"success"`
 }
 
 // The parameters of a notification message.
-type ShowMessageParams struct { // line 4183
+type ShowMessageParams struct {
 	// The message type. See {@link MessageType}
 	Type MessageType `json:"type"`
 	// The actual message.
@@ -3974,11 +4182,11 @@ type ShowMessageParams struct { // line 4183
 }
 
 // Show message request client capabilities
-type ShowMessageRequestClientCapabilities struct { // line 12458
+type ShowMessageRequestClientCapabilities struct {
 	// Capabilities specific to the `MessageActionItem` type.
-	MessageActionItem *PMessageActionItemPShowMessage `json:"messageActionItem,omitempty"`
+	MessageActionItem *ClientShowMessageActionItemOptions `json:"messageActionItem,omitempty"`
 }
-type ShowMessageRequestParams struct { // line 4205
+type ShowMessageRequestParams struct {
 	// The message type. See {@link MessageType}
 	Type MessageType `json:"type"`
 	// The actual message.
@@ -3990,7 +4198,7 @@ type ShowMessageRequestParams struct { // line 4205
 // Signature help represents the signature of something
 // callable. There can be multiple signature but only one
 // active and only one active parameter.
-type SignatureHelp struct { // line 4968
+type SignatureHelp struct {
 	// One or more signatures.
 	Signatures []SignatureInformation `json:"signatures"`
 	// The active signature. If omitted or the value lies outside the
@@ -4014,12 +4222,12 @@ type SignatureHelp struct { // line 4968
 }
 
 // Client Capabilities for a {@link SignatureHelpRequest}.
-type SignatureHelpClientCapabilities struct { // line 11428
+type SignatureHelpClientCapabilities struct {
 	// Whether signature help supports dynamic registration.
 	DynamicRegistration bool `json:"dynamicRegistration,omitempty"`
 	// The client supports the following `SignatureInformation`
 	// specific properties.
-	SignatureInformation *PSignatureInformationPSignatureHelp `json:"signatureInformation,omitempty"`
+	SignatureInformation *ClientSignatureInformationOptions `json:"signatureInformation,omitempty"`
 	// The client supports to send additional context information for a
 	// `textDocument/signatureHelp` request. A client that opts into
 	// contextSupport will also support the `retriggerCharacters` on
@@ -4032,7 +4240,7 @@ type SignatureHelpClientCapabilities struct { // line 11428
 // Additional information about the context in which a signature help request was triggered.
 //
 // @since 3.15.0
-type SignatureHelpContext struct { // line 8787
+type SignatureHelpContext struct {
 	// Action that caused signature help to be triggered.
 	TriggerKind SignatureHelpTriggerKind `json:"triggerKind"`
 	// Character that caused signature help to be triggered.
@@ -4052,7 +4260,7 @@ type SignatureHelpContext struct { // line 8787
 }
 
 // Server Capabilities for a {@link SignatureHelpRequest}.
-type SignatureHelpOptions struct { // line 8882
+type SignatureHelpOptions struct {
 	// List of characters that trigger signature help automatically.
 	TriggerCharacters []string `json:"triggerCharacters,omitempty"`
 	// List of characters that re-trigger signature help.
@@ -4066,7 +4274,7 @@ type SignatureHelpOptions struct { // line 8882
 }
 
 // Parameters for a {@link SignatureHelpRequest}.
-type SignatureHelpParams struct { // line 4940
+type SignatureHelpParams struct {
 	// The signature help context. This is only available if the client specifies
 	// to send this using the client capability `textDocument.signatureHelp.contextSupport === true`
 	//
@@ -4077,7 +4285,7 @@ type SignatureHelpParams struct { // line 4940
 }
 
 // Registration options for a {@link SignatureHelpRequest}.
-type SignatureHelpRegistrationOptions struct { // line 5003
+type SignatureHelpRegistrationOptions struct {
 	TextDocumentRegistrationOptions
 	SignatureHelpOptions
 }
@@ -4085,11 +4293,12 @@ type SignatureHelpRegistrationOptions struct { // line 5003
 // How a signature help was triggered.
 //
 // @since 3.15.0
-type SignatureHelpTriggerKind uint32 // line 13580
+type SignatureHelpTriggerKind uint32
+
 // Represents the signature of something callable. A signature
 // can have a label, like a function-name, a doc-comment, and
 // a set of parameters.
-type SignatureInformation struct { // line 8828
+type SignatureInformation struct {
 	// The label of this signature. Will be shown in
 	// the UI.
 	Label string `json:"label"`
@@ -4106,17 +4315,45 @@ type SignatureInformation struct { // line 8828
 	ActiveParameter uint32 `json:"activeParameter,omitempty"`
 }
 
+// @since 3.18.0
+// @proposed
+type StaleRequestSupportOptions struct {
+	// The client will actively cancel the request.
+	Cancel bool `json:"cancel"`
+	// The list of requests for which the client
+	// will retry the request if it receives a
+	// response with error code `ContentModified`
+	RetryOnContentModified []string `json:"retryOnContentModified"`
+}
+
 // Static registration options to be returned in the initialize
 // request.
-type StaticRegistrationOptions struct { // line 6343
+type StaticRegistrationOptions struct {
 	// The id used to register the request. The id can be used to deregister
 	// the request again. See also Registration#id.
 	ID string `json:"id,omitempty"`
 }
 
+// A string value used as a snippet is a template which allows to insert text
+// and to control the editor cursor when insertion happens.
+//
+// A snippet can define tab stops and placeholders with `$1`, `$2`
+// and `${3:foo}`. `$0` defines the final tab stop, it defaults to
+// the end of the snippet. Variables are defined with `$name` and
+// `${name:default value}`.
+//
+// @since 3.18.0
+// @proposed
+type StringValue struct {
+	// The kind of string value.
+	Kind string `json:"kind"`
+	// The snippet string.
+	Value string `json:"value"`
+}
+
 // Represents information about programming constructs like variables, classes,
 // interfaces etc.
-type SymbolInformation struct { // line 5181
+type SymbolInformation struct {
 	// extends BaseSymbolInformation
 	// Indicates if this symbol is deprecated.
 	//
@@ -4148,20 +4385,22 @@ type SymbolInformation struct { // line 5181
 }
 
 // A symbol kind.
-type SymbolKind uint32 // line 12841
+type SymbolKind uint32
+
 // Symbol tags are extra annotations that tweak the rendering of a symbol.
 //
 // @since 3.16
-type SymbolTag uint32 // line 12955
+type SymbolTag uint32
+
 // Describe options to be used when registered for text document change events.
-type TextDocumentChangeRegistrationOptions struct { // line 4312
+type TextDocumentChangeRegistrationOptions struct {
 	// How documents are synced to the server.
 	SyncKind TextDocumentSyncKind `json:"syncKind"`
 	TextDocumentRegistrationOptions
 }
 
 // Text document specific client capabilities.
-type TextDocumentClientCapabilities struct { // line 10323
+type TextDocumentClientCapabilities struct {
 	// Defines which synchronization capabilities the client supports.
 	Synchronization *TextDocumentSyncClientCapabilities `json:"synchronization,omitempty"`
 	// Capabilities specific to the `textDocument/completion` request.
@@ -4251,23 +4490,48 @@ type TextDocumentClientCapabilities struct { // line 10323
 	//
 	// @since 3.17.0
 	Diagnostic *DiagnosticClientCapabilities `json:"diagnostic,omitempty"`
+	// Client capabilities specific to inline completions.
+	//
+	// @since 3.18.0
+	// @proposed
+	InlineCompletion *InlineCompletionClientCapabilities `json:"inlineCompletion,omitempty"`
 }
 
 // An event describing a change to a text document. If only a text is provided
 // it is considered to be the full content of the document.
-type TextDocumentContentChangeEvent = Msg_TextDocumentContentChangeEvent // (alias) line 14002
+type TextDocumentContentChangeEvent = TextDocumentContentChangePartial // (alias)
+// @since 3.18.0
+// @proposed
+type TextDocumentContentChangePartial struct {
+	// The range of the document that changed.
+	Range *Range `json:"range,omitempty"`
+	// The optional length of the range that got replaced.
+	//
+	// @deprecated use range instead.
+	RangeLength uint32 `json:"rangeLength,omitempty"`
+	// The new text for the provided range.
+	Text string `json:"text"`
+}
+
+// @since 3.18.0
+// @proposed
+type TextDocumentContentChangeWholeDocument struct {
+	// The new text of the whole document.
+	Text string `json:"text"`
+}
+
 // Describes textual changes on a text document. A TextDocumentEdit describes all changes
 // on a document version Si and after they are applied move the document to version Si+1.
 // So the creator of a TextDocumentEdit doesn't need to sort the array of edits or do any
 // kind of ordering. However the edits must be non overlapping.
-type TextDocumentEdit struct { // line 6677
+type TextDocumentEdit struct {
 	// The text document to change.
 	TextDocument OptionalVersionedTextDocumentIdentifier `json:"textDocument"`
 	// The edits to be applied.
 	//
 	// @since 3.16.0 - support for AnnotatedTextEdit. This is guarded using a
 	// client capability.
-	Edits []TextEdit `json:"edits"`
+	Edits []Or_TextDocumentEdit_edits_Elem `json:"edits"`
 }
 
 // A document filter denotes a document by different properties like
@@ -4287,16 +4551,55 @@ type TextDocumentEdit struct { // line 6677
 // @sample A language filter that applies to all package.json paths: `{ language: 'json', pattern: '**package.json' }`
 //
 // @since 3.17.0
-type TextDocumentFilter = Msg_TextDocumentFilter // (alias) line 14145
+type TextDocumentFilter = Or_TextDocumentFilter // (alias)
+// A document filter where `language` is required field.
+//
+// @since 3.18.0
+// @proposed
+type TextDocumentFilterLanguage struct {
+	// A language id, like `typescript`.
+	Language string `json:"language"`
+	// A Uri {@link Uri.scheme scheme}, like `file` or `untitled`.
+	Scheme string `json:"scheme,omitempty"`
+	// A glob pattern, like **​/*.{ts,js}. See TextDocumentFilter for examples.
+	Pattern string `json:"pattern,omitempty"`
+}
+
+// A document filter where `pattern` is required field.
+//
+// @since 3.18.0
+// @proposed
+type TextDocumentFilterPattern struct {
+	// A language id, like `typescript`.
+	Language string `json:"language,omitempty"`
+	// A Uri {@link Uri.scheme scheme}, like `file` or `untitled`.
+	Scheme string `json:"scheme,omitempty"`
+	// A glob pattern, like **​/*.{ts,js}. See TextDocumentFilter for examples.
+	Pattern string `json:"pattern"`
+}
+
+// A document filter where `scheme` is required field.
+//
+// @since 3.18.0
+// @proposed
+type TextDocumentFilterScheme struct {
+	// A language id, like `typescript`.
+	Language string `json:"language,omitempty"`
+	// A Uri {@link Uri.scheme scheme}, like `file` or `untitled`.
+	Scheme string `json:"scheme"`
+	// A glob pattern, like **​/*.{ts,js}. See TextDocumentFilter for examples.
+	Pattern string `json:"pattern,omitempty"`
+}
+
 // A literal to identify a text document in the client.
-type TextDocumentIdentifier struct { // line 6419
+type TextDocumentIdentifier struct {
 	// The text document's uri.
 	URI DocumentURI `json:"uri"`
 }
 
 // An item to transfer a text document from the client to the
 // server.
-type TextDocumentItem struct { // line 7405
+type TextDocumentItem struct {
 	// The text document's uri.
 	URI DocumentURI `json:"uri"`
 	// The text document's language identifier.
@@ -4310,7 +4613,7 @@ type TextDocumentItem struct { // line 7405
 
 // A parameter literal used in requests to pass a text document and a position inside that
 // document.
-type TextDocumentPositionParams struct { // line 6222
+type TextDocumentPositionParams struct {
 	// The text document.
 	TextDocument TextDocumentIdentifier `json:"textDocument"`
 	// The position inside the text document.
@@ -4318,20 +4621,21 @@ type TextDocumentPositionParams struct { // line 6222
 }
 
 // General text document registration options.
-type TextDocumentRegistrationOptions struct { // line 2368
+type TextDocumentRegistrationOptions struct {
 	// A document selector to identify the scope of the registration. If set to null
 	// the document selector provided on the client side will be used.
 	DocumentSelector DocumentSelector `json:"documentSelector"`
 }
 
 // Represents reasons why a text document is saved.
-type TextDocumentSaveReason uint32 // line 13109
+type TextDocumentSaveReason uint32
+
 // Save registration options.
-type TextDocumentSaveRegistrationOptions struct { // line 4369
+type TextDocumentSaveRegistrationOptions struct {
 	TextDocumentRegistrationOptions
 	SaveOptions
 }
-type TextDocumentSyncClientCapabilities struct { // line 11127
+type TextDocumentSyncClientCapabilities struct {
 	// Whether text document synchronization supports dynamic registration.
 	DynamicRegistration bool `json:"dynamicRegistration,omitempty"`
 	// The client supports sending will save notifications.
@@ -4346,8 +4650,8 @@ type TextDocumentSyncClientCapabilities struct { // line 11127
 
 // Defines how the host (editor) should sync
 // document changes to the language server.
-type TextDocumentSyncKind uint32      // line 13084
-type TextDocumentSyncOptions struct { // line 9736
+type TextDocumentSyncKind uint32
+type TextDocumentSyncOptions struct {
 	// Open and close notifications are sent to the server. If omitted open close notification should not
 	// be sent.
 	OpenClose bool `json:"openClose,omitempty"`
@@ -4366,7 +4670,7 @@ type TextDocumentSyncOptions struct { // line 9736
 }
 
 // A text edit applicable to a text document.
-type TextEdit struct { // line 4406
+type TextEdit struct {
 	// The range of the text document to be manipulated. To insert
 	// text into a document create a range where start === end.
 	Range Range `json:"range"`
@@ -4374,10 +4678,11 @@ type TextEdit struct { // line 4406
 	// empty string.
 	NewText string `json:"newText"`
 }
-type TokenFormat string // line 13736
-type TraceValues string // line 13383
+type TokenFormat string
+type TraceValues string
+
 // Since 3.6.0
-type TypeDefinitionClientCapabilities struct { // line 11559
+type TypeDefinitionClientCapabilities struct {
 	// Whether implementation supports dynamic registration. If this is set to `true`
 	// the client supports the new `TypeDefinitionRegistrationOptions` return value
 	// for the corresponding server capability as well.
@@ -4387,22 +4692,22 @@ type TypeDefinitionClientCapabilities struct { // line 11559
 	// Since 3.14.0
 	LinkSupport bool `json:"linkSupport,omitempty"`
 }
-type TypeDefinitionOptions struct { // line 6358
+type TypeDefinitionOptions struct {
 	WorkDoneProgressOptions
 }
-type TypeDefinitionParams struct { // line 2123
+type TypeDefinitionParams struct {
 	TextDocumentPositionParams
 	WorkDoneProgressParams
 	PartialResultParams
 }
-type TypeDefinitionRegistrationOptions struct { // line 2143
+type TypeDefinitionRegistrationOptions struct {
 	TextDocumentRegistrationOptions
 	TypeDefinitionOptions
 	StaticRegistrationOptions
 }
 
 // @since 3.17.0
-type TypeHierarchyClientCapabilities struct { // line 12337
+type TypeHierarchyClientCapabilities struct {
 	// Whether implementation supports dynamic registration. If this is set to `true`
 	// the client supports the new `(TextDocumentRegistrationOptions & StaticRegistrationOptions)`
 	// return value for the corresponding server capability as well.
@@ -4410,7 +4715,7 @@ type TypeHierarchyClientCapabilities struct { // line 12337
 }
 
 // @since 3.17.0
-type TypeHierarchyItem struct { // line 3410
+type TypeHierarchyItem struct {
 	// The name of this item.
 	Name string `json:"name"`
 	// The kind of this item.
@@ -4438,14 +4743,14 @@ type TypeHierarchyItem struct { // line 3410
 // Type hierarchy options used during static registration.
 //
 // @since 3.17.0
-type TypeHierarchyOptions struct { // line 6936
+type TypeHierarchyOptions struct {
 	WorkDoneProgressOptions
 }
 
 // The parameter of a `textDocument/prepareTypeHierarchy` request.
 //
 // @since 3.17.0
-type TypeHierarchyPrepareParams struct { // line 3392
+type TypeHierarchyPrepareParams struct {
 	TextDocumentPositionParams
 	WorkDoneProgressParams
 }
@@ -4453,7 +4758,7 @@ type TypeHierarchyPrepareParams struct { // line 3392
 // Type hierarchy options used during static or dynamic registration.
 //
 // @since 3.17.0
-type TypeHierarchyRegistrationOptions struct { // line 3487
+type TypeHierarchyRegistrationOptions struct {
 	TextDocumentRegistrationOptions
 	TypeHierarchyOptions
 	StaticRegistrationOptions
@@ -4462,7 +4767,7 @@ type TypeHierarchyRegistrationOptions struct { // line 3487
 // The parameter of a `typeHierarchy/subtypes` request.
 //
 // @since 3.17.0
-type TypeHierarchySubtypesParams struct { // line 3533
+type TypeHierarchySubtypesParams struct {
 	Item TypeHierarchyItem `json:"item"`
 	WorkDoneProgressParams
 	PartialResultParams
@@ -4471,24 +4776,25 @@ type TypeHierarchySubtypesParams struct { // line 3533
 // The parameter of a `typeHierarchy/supertypes` request.
 //
 // @since 3.17.0
-type TypeHierarchySupertypesParams struct { // line 3509
+type TypeHierarchySupertypesParams struct {
 	Item TypeHierarchyItem `json:"item"`
 	WorkDoneProgressParams
 	PartialResultParams
 }
 
 // created for Tuple
-type UIntCommaUInt struct { // line 10076
+type UIntCommaUInt struct {
 	Fld0 uint32 `json:"fld0"`
 	Fld1 uint32 `json:"fld1"`
 }
+
 type URI = string
 
 // A diagnostic report indicating that the last returned
 // report is still accurate.
 //
 // @since 3.17.0
-type UnchangedDocumentDiagnosticReport struct { // line 7270
+type UnchangedDocumentDiagnosticReport struct {
 	// A document diagnostic report indicating
 	// no changes to the last result. A server can
 	// only return `unchanged` if result ids are
@@ -4502,23 +4808,24 @@ type UnchangedDocumentDiagnosticReport struct { // line 7270
 // Moniker uniqueness level to define scope of the moniker.
 //
 // @since 3.16.0
-type UniquenessLevel string // line 12971
+type UniquenessLevel string
+
 // General parameters to unregister a request or notification.
-type Unregistration struct { // line 7628
+type Unregistration struct {
 	// The id used to unregister the request or notification. Usually an id
 	// provided during the register request.
 	ID string `json:"id"`
 	// The method to unregister for.
 	Method string `json:"method"`
 }
-type UnregistrationParams struct { // line 4053
+type UnregistrationParams struct {
 	Unregisterations []Unregistration `json:"unregisterations"`
 }
 
 // A versioned notebook document identifier.
 //
 // @since 3.17.0
-type VersionedNotebookDocumentIdentifier struct { // line 7443
+type VersionedNotebookDocumentIdentifier struct {
 	// The version number of this notebook document.
 	Version int32 `json:"version"`
 	// The notebook document's uri.
@@ -4526,19 +4833,19 @@ type VersionedNotebookDocumentIdentifier struct { // line 7443
 }
 
 // A text document identifier to denote a specific version of a text document.
-type VersionedTextDocumentIdentifier struct { // line 8445
+type VersionedTextDocumentIdentifier struct {
 	// The version number of this document.
 	Version int32 `json:"version"`
 	TextDocumentIdentifier
 }
-type WatchKind = uint32                  // line 13505// The parameters sent in a will save text document notification.
-type WillSaveTextDocumentParams struct { // line 4384
+type WatchKind = uint32 // The parameters sent in a will save text document notification.
+type WillSaveTextDocumentParams struct {
 	// The document that will be saved.
 	TextDocument TextDocumentIdentifier `json:"textDocument"`
 	// The 'TextDocumentSaveReason'.
 	Reason TextDocumentSaveReason `json:"reason"`
 }
-type WindowClientCapabilities struct { // line 10629
+type WindowClientCapabilities struct {
 	// It indicates whether the client supports server initiated
 	// progress using the `window/workDoneProgress/create` request.
 	//
@@ -4558,7 +4865,7 @@ type WindowClientCapabilities struct { // line 10629
 	// @since 3.16.0
 	ShowDocument *ShowDocumentClientCapabilities `json:"showDocument,omitempty"`
 }
-type WorkDoneProgressBegin struct { // line 6040
+type WorkDoneProgressBegin struct {
 	Kind string `json:"kind"`
 	// Mandatory title of the progress operation. Used to briefly inform about
 	// the kind of operation being performed.
@@ -4583,34 +4890,34 @@ type WorkDoneProgressBegin struct { // line 6040
 	// that are not following this rule. The value range is [0, 100].
 	Percentage uint32 `json:"percentage,omitempty"`
 }
-type WorkDoneProgressCancelParams struct { // line 2625
+type WorkDoneProgressCancelParams struct {
 	// The token to be used to report progress.
 	Token ProgressToken `json:"token"`
 }
-type WorkDoneProgressCreateParams struct { // line 2612
+type WorkDoneProgressCreateParams struct {
 	// The token to be used to report progress.
 	Token ProgressToken `json:"token"`
 }
-type WorkDoneProgressEnd struct { // line 6126
+type WorkDoneProgressEnd struct {
 	Kind string `json:"kind"`
 	// Optional, a final message indicating to for example indicate the outcome
 	// of the operation.
 	Message string `json:"message,omitempty"`
 }
-type WorkDoneProgressOptions struct { // line 2355
+type WorkDoneProgressOptions struct {
 	WorkDoneProgress bool `json:"workDoneProgress,omitempty"`
 }
 
 // created for And
-type WorkDoneProgressOptionsAndTextDocumentRegistrationOptions struct { // line 196
+type WorkDoneProgressOptionsAndTextDocumentRegistrationOptions struct {
 	WorkDoneProgressOptions
 	TextDocumentRegistrationOptions
 }
-type WorkDoneProgressParams struct { // line 6244
+type WorkDoneProgressParams struct {
 	// An optional token that a server can use to report work done progress.
 	WorkDoneToken ProgressToken `json:"workDoneToken,omitempty"`
 }
-type WorkDoneProgressReport struct { // line 6087
+type WorkDoneProgressReport struct {
 	Kind string `json:"kind"`
 	// Controls enablement state of a cancel button.
 	//
@@ -4632,20 +4939,8 @@ type WorkDoneProgressReport struct { // line 6087
 	Percentage uint32 `json:"percentage,omitempty"`
 }
 
-// created for Literal (Lit_ServerCapabilities_workspace)
-type Workspace6Gn struct { // line 8404
-	// The server supports workspace folder.
-	//
-	// @since 3.6.0
-	WorkspaceFolders *WorkspaceFolders5Gn `json:"workspaceFolders,omitempty"`
-	// The server is interested in notifications/requests for operations on files.
-	//
-	// @since 3.16.0
-	FileOperations *FileOperationOptions `json:"fileOperations,omitempty"`
-}
-
 // Workspace specific client capabilities.
-type WorkspaceClientCapabilities struct { // line 10184
+type WorkspaceClientCapabilities struct {
 	// The client supports applying batch edits
 	// to the workspace by supporting the request
 	// 'workspace/applyEdit'
@@ -4697,12 +4992,17 @@ type WorkspaceClientCapabilities struct { // line 10184
 	//
 	// @since 3.17.0.
 	Diagnostics *DiagnosticWorkspaceClientCapabilities `json:"diagnostics,omitempty"`
+	// Capabilities specific to the folding range requests scoped to the workspace.
+	//
+	// @since 3.18.0
+	// @proposed
+	FoldingRange *FoldingRangeWorkspaceClientCapabilities `json:"foldingRange,omitempty"`
 }
 
 // Parameters of the workspace diagnostic request.
 //
 // @since 3.17.0
-type WorkspaceDiagnosticParams struct { // line 3877
+type WorkspaceDiagnosticParams struct {
 	// The additional identifier provided during registration.
 	Identifier string `json:"identifier,omitempty"`
 	// The currently known diagnostic reports with their
@@ -4715,21 +5015,21 @@ type WorkspaceDiagnosticParams struct { // line 3877
 // A workspace diagnostic report.
 //
 // @since 3.17.0
-type WorkspaceDiagnosticReport struct { // line 3914
+type WorkspaceDiagnosticReport struct {
 	Items []WorkspaceDocumentDiagnosticReport `json:"items"`
 }
 
 // A partial result for a workspace diagnostic report.
 //
 // @since 3.17.0
-type WorkspaceDiagnosticReportPartialResult struct { // line 3931
+type WorkspaceDiagnosticReportPartialResult struct {
 	Items []WorkspaceDocumentDiagnosticReport `json:"items"`
 }
 
 // A workspace diagnostic document report.
 //
 // @since 3.17.0
-type WorkspaceDocumentDiagnosticReport = Or_WorkspaceDocumentDiagnosticReport // (alias) line 13984
+type WorkspaceDocumentDiagnosticReport = Or_WorkspaceDocumentDiagnosticReport // (alias)
 // A workspace edit represents changes to many resources managed in the workspace. The edit
 // should either provide `changes` or `documentChanges`. If documentChanges are present
 // they are preferred over `changes` if the client can handle versioned document edits.
@@ -4742,7 +5042,7 @@ type WorkspaceDocumentDiagnosticReport = Or_WorkspaceDocumentDiagnosticReport //
 // An invalid sequence (e.g. (1) delete file a.txt and (2) insert text into file a.txt) will
 // cause failure of the operation. How the client recovers from the failure is described by
 // the client capability: `workspace.workspaceEdit.failureHandling`
-type WorkspaceEdit struct { // line 3193
+type WorkspaceEdit struct {
 	// Holds changes to existing resources.
 	Changes map[DocumentURI][]TextEdit `json:"changes,omitempty"`
 	// Depending on the client capability `workspace.workspaceEdit.resourceOperations` document changes
@@ -4764,7 +5064,7 @@ type WorkspaceEdit struct { // line 3193
 	// @since 3.16.0
 	ChangeAnnotations map[ChangeAnnotationIdentifier]ChangeAnnotation `json:"changeAnnotations,omitempty"`
 }
-type WorkspaceEditClientCapabilities struct { // line 10768
+type WorkspaceEditClientCapabilities struct {
 	// The client supports versioned document changes in `WorkspaceEdit`s
 	DocumentChanges bool `json:"documentChanges,omitempty"`
 	// The resource operations the client supports. Clients should at least
@@ -4789,18 +5089,18 @@ type WorkspaceEditClientCapabilities struct { // line 10768
 	// create file, rename file and delete file changes.
 	//
 	// @since 3.16.0
-	ChangeAnnotationSupport *PChangeAnnotationSupportPWorkspaceEdit `json:"changeAnnotationSupport,omitempty"`
+	ChangeAnnotationSupport *ChangeAnnotationsSupportOptions `json:"changeAnnotationSupport,omitempty"`
 }
 
 // A workspace folder inside a client.
-type WorkspaceFolder struct { // line 2163
+type WorkspaceFolder struct {
 	// The associated URI for this workspace folder.
 	URI URI `json:"uri"`
 	// The name of the workspace folder. Used to refer to this
 	// workspace folder in the user interface.
 	Name string `json:"name"`
 }
-type WorkspaceFolders5Gn struct { // line 9933
+type WorkspaceFolders5Gn struct {
 	// The server has support for workspace folders
 	Supported bool `json:"supported,omitempty"`
 	// Whether the server wants to receive workspace folder
@@ -4814,13 +5114,13 @@ type WorkspaceFolders5Gn struct { // line 9933
 }
 
 // The workspace folder change event.
-type WorkspaceFoldersChangeEvent struct { // line 6368
+type WorkspaceFoldersChangeEvent struct {
 	// The array of added workspace folders
 	Added []WorkspaceFolder `json:"added"`
 	// The array of the removed workspace folders
 	Removed []WorkspaceFolder `json:"removed"`
 }
-type WorkspaceFoldersInitializeParams struct { // line 7782
+type WorkspaceFoldersInitializeParams struct {
 	// The workspace folders configured in the client when the server starts.
 	//
 	// This property is only available if the client supports workspace folders.
@@ -4830,7 +5130,7 @@ type WorkspaceFoldersInitializeParams struct { // line 7782
 	// @since 3.6.0
 	WorkspaceFolders []WorkspaceFolder `json:"workspaceFolders,omitempty"`
 }
-type WorkspaceFoldersServerCapabilities struct { // line 9933
+type WorkspaceFoldersServerCapabilities struct {
 	// The server has support for workspace folders
 	Supported bool `json:"supported,omitempty"`
 	// Whether the server wants to receive workspace folder
@@ -4846,7 +5146,7 @@ type WorkspaceFoldersServerCapabilities struct { // line 9933
 // A full document diagnostic report for a workspace diagnostic result.
 //
 // @since 3.17.0
-type WorkspaceFullDocumentDiagnosticReport struct { // line 9522
+type WorkspaceFullDocumentDiagnosticReport struct {
 	// The URI for which diagnostic information is reported.
 	URI DocumentURI `json:"uri"`
 	// The version number for which the diagnostics are reported.
@@ -4855,12 +5155,27 @@ type WorkspaceFullDocumentDiagnosticReport struct { // line 9522
 	FullDocumentDiagnosticReport
 }
 
+// Defines workspace specific capabilities of the server.
+//
+// @since 3.18.0
+// @proposed
+type WorkspaceOptions struct {
+	// The server supports workspace folder.
+	//
+	// @since 3.6.0
+	WorkspaceFolders *WorkspaceFolders5Gn `json:"workspaceFolders,omitempty"`
+	// The server is interested in notifications/requests for operations on files.
+	//
+	// @since 3.16.0
+	FileOperations *FileOperationOptions `json:"fileOperations,omitempty"`
+}
+
 // A special workspace symbol that supports locations without a range.
 //
 // See also SymbolInformation.
 //
 // @since 3.17.0
-type WorkspaceSymbol struct { // line 5515
+type WorkspaceSymbol struct {
 	// The location of the symbol. Whether a server is allowed to
 	// return a location without a range depends on the client
 	// capability `workspace.symbol.resolveSupport`.
@@ -4874,26 +5189,26 @@ type WorkspaceSymbol struct { // line 5515
 }
 
 // Client capabilities for a {@link WorkspaceSymbolRequest}.
-type WorkspaceSymbolClientCapabilities struct { // line 10875
+type WorkspaceSymbolClientCapabilities struct {
 	// Symbol request supports dynamic registration.
 	DynamicRegistration bool `json:"dynamicRegistration,omitempty"`
 	// Specific capabilities for the `SymbolKind` in the `workspace/symbol` request.
-	SymbolKind *PSymbolKindPSymbol `json:"symbolKind,omitempty"`
+	SymbolKind *ClientSymbolKindOptions `json:"symbolKind,omitempty"`
 	// The client supports tags on `SymbolInformation`.
 	// Clients supporting tags have to handle unknown tags gracefully.
 	//
 	// @since 3.16.0
-	TagSupport *PTagSupportPSymbol `json:"tagSupport,omitempty"`
+	TagSupport *ClientSymbolTagOptions `json:"tagSupport,omitempty"`
 	// The client support partial workspace symbols. The client will send the
 	// request `workspaceSymbol/resolve` to the server to resolve additional
 	// properties.
 	//
 	// @since 3.17.0
-	ResolveSupport *PResolveSupportPSymbol `json:"resolveSupport,omitempty"`
+	ResolveSupport *ClientSymbolResolveOptions `json:"resolveSupport,omitempty"`
 }
 
 // Server capabilities for a {@link WorkspaceSymbolRequest}.
-type WorkspaceSymbolOptions struct { // line 9105
+type WorkspaceSymbolOptions struct {
 	// The server provides support to resolve additional
 	// information for a workspace symbol.
 	//
@@ -4903,7 +5218,7 @@ type WorkspaceSymbolOptions struct { // line 9105
 }
 
 // The parameters of a {@link WorkspaceSymbolRequest}.
-type WorkspaceSymbolParams struct { // line 5491
+type WorkspaceSymbolParams struct {
 	// A query string to filter symbols by. Clients may send an empty
 	// string here to request all symbols.
 	Query string `json:"query"`
@@ -4912,14 +5227,14 @@ type WorkspaceSymbolParams struct { // line 5491
 }
 
 // Registration options for a {@link WorkspaceSymbolRequest}.
-type WorkspaceSymbolRegistrationOptions struct { // line 5564
+type WorkspaceSymbolRegistrationOptions struct {
 	WorkspaceSymbolOptions
 }
 
 // An unchanged document diagnostic report for a workspace diagnostic result.
 //
 // @since 3.17.0
-type WorkspaceUnchangedDocumentDiagnosticReport struct { // line 9560
+type WorkspaceUnchangedDocumentDiagnosticReport struct {
 	// The URI for which diagnostic information is reported.
 	URI DocumentURI `json:"uri"`
 	// The version number for which the diagnostics are reported.
@@ -4929,7 +5244,7 @@ type WorkspaceUnchangedDocumentDiagnosticReport struct { // line 9560
 }
 
 // The initialize parameters
-type XInitializeParams struct { // line 7650
+type XInitializeParams struct {
 	// The process Id of the parent process that started
 	// the server.
 	//
@@ -4939,7 +5254,7 @@ type XInitializeParams struct { // line 7650
 	// Information about the client
 	//
 	// @since 3.15.0
-	ClientInfo *Msg_XInitializeParams_clientInfo `json:"clientInfo,omitempty"`
+	ClientInfo *ClientInfo `json:"clientInfo,omitempty"`
 	// The locale the client is currently showing the user interface
 	// in. This must not necessarily be the locale of the operating
 	// system.
@@ -4970,7 +5285,7 @@ type XInitializeParams struct { // line 7650
 }
 
 // The initialize parameters
-type _InitializeParams struct { // line 7650
+type _InitializeParams struct {
 	// The process Id of the parent process that started
 	// the server.
 	//
@@ -4980,7 +5295,7 @@ type _InitializeParams struct { // line 7650
 	// Information about the client
 	//
 	// @since 3.15.0
-	ClientInfo *Msg_XInitializeParams_clientInfo `json:"clientInfo,omitempty"`
+	ClientInfo *ClientInfo `json:"clientInfo,omitempty"`
 	// The locale the client is currently showing the user interface
 	// in. This must not necessarily be the locale of the operating
 	// system.
@@ -5013,11 +5328,11 @@ type _InitializeParams struct { // line 7650
 const (
 	// A set of predefined code action kinds
 	// Empty kind.
-	Empty CodeActionKind = "" // line 13333
+	Empty CodeActionKind = ""
 	// Base kind for quickfix actions: 'quickfix'
-	QuickFix CodeActionKind = "quickfix" // line 13338
+	QuickFix CodeActionKind = "quickfix"
 	// Base kind for refactoring actions: 'refactor'
-	Refactor CodeActionKind = "refactor" // line 13343
+	Refactor CodeActionKind = "refactor"
 	// Base kind for refactoring extraction actions: 'refactor.extract'
 	//
 	// Example extract actions:
@@ -5028,7 +5343,7 @@ const (
 	//  - Extract variable
 	//  - Extract interface from class
 	//  - ...
-	RefactorExtract CodeActionKind = "refactor.extract" // line 13348
+	RefactorExtract CodeActionKind = "refactor.extract"
 	// Base kind for refactoring inline actions: 'refactor.inline'
 	//
 	// Example inline actions:
@@ -5038,7 +5353,7 @@ const (
 	//  - Inline variable
 	//  - Inline constant
 	//  - ...
-	RefactorInline CodeActionKind = "refactor.inline" // line 13353
+	RefactorInline CodeActionKind = "refactor.inline"
 	// Base kind for refactoring rewrite actions: 'refactor.rewrite'
 	//
 	// Example rewrite actions:
@@ -5050,80 +5365,80 @@ const (
 	//  - Make method static
 	//  - Move method to base class
 	//  - ...
-	RefactorRewrite CodeActionKind = "refactor.rewrite" // line 13358
+	RefactorRewrite CodeActionKind = "refactor.rewrite"
 	// Base kind for source actions: `source`
 	//
 	// Source code actions apply to the entire file.
-	Source CodeActionKind = "source" // line 13363
+	Source CodeActionKind = "source"
 	// Base kind for an organize imports source action: `source.organizeImports`
-	SourceOrganizeImports CodeActionKind = "source.organizeImports" // line 13368
+	SourceOrganizeImports CodeActionKind = "source.organizeImports"
 	// Base kind for auto-fix source actions: `source.fixAll`.
 	//
 	// Fix all actions automatically fix errors that have a clear fix that do not require user input.
 	// They should not suppress errors or perform unsafe fixes such as generating new types or classes.
 	//
 	// @since 3.15.0
-	SourceFixAll CodeActionKind = "source.fixAll" // line 13373
+	SourceFixAll CodeActionKind = "source.fixAll"
 	// The reason why code actions were requested.
 	//
 	// @since 3.17.0
 	// Code actions were explicitly requested by the user or by an extension.
-	CodeActionInvoked CodeActionTriggerKind = 1 // line 13613
+	CodeActionInvoked CodeActionTriggerKind = 1
 	// Code actions were requested automatically.
 	//
 	// This typically happens when current selection in a file changes, but can
 	// also be triggered when file content changes.
-	CodeActionAutomatic CodeActionTriggerKind = 2 // line 13618
+	CodeActionAutomatic CodeActionTriggerKind = 2
 	// The kind of a completion entry.
-	TextCompletion          CompletionItemKind = 1  // line 13141
-	MethodCompletion        CompletionItemKind = 2  // line 13145
-	FunctionCompletion      CompletionItemKind = 3  // line 13149
-	ConstructorCompletion   CompletionItemKind = 4  // line 13153
-	FieldCompletion         CompletionItemKind = 5  // line 13157
-	VariableCompletion      CompletionItemKind = 6  // line 13161
-	ClassCompletion         CompletionItemKind = 7  // line 13165
-	InterfaceCompletion     CompletionItemKind = 8  // line 13169
-	ModuleCompletion        CompletionItemKind = 9  // line 13173
-	PropertyCompletion      CompletionItemKind = 10 // line 13177
-	UnitCompletion          CompletionItemKind = 11 // line 13181
-	ValueCompletion         CompletionItemKind = 12 // line 13185
-	EnumCompletion          CompletionItemKind = 13 // line 13189
-	KeywordCompletion       CompletionItemKind = 14 // line 13193
-	SnippetCompletion       CompletionItemKind = 15 // line 13197
-	ColorCompletion         CompletionItemKind = 16 // line 13201
-	FileCompletion          CompletionItemKind = 17 // line 13205
-	ReferenceCompletion     CompletionItemKind = 18 // line 13209
-	FolderCompletion        CompletionItemKind = 19 // line 13213
-	EnumMemberCompletion    CompletionItemKind = 20 // line 13217
-	ConstantCompletion      CompletionItemKind = 21 // line 13221
-	StructCompletion        CompletionItemKind = 22 // line 13225
-	EventCompletion         CompletionItemKind = 23 // line 13229
-	OperatorCompletion      CompletionItemKind = 24 // line 13233
-	TypeParameterCompletion CompletionItemKind = 25 // line 13237
+	TextCompletion          CompletionItemKind = 1
+	MethodCompletion        CompletionItemKind = 2
+	FunctionCompletion      CompletionItemKind = 3
+	ConstructorCompletion   CompletionItemKind = 4
+	FieldCompletion         CompletionItemKind = 5
+	VariableCompletion      CompletionItemKind = 6
+	ClassCompletion         CompletionItemKind = 7
+	InterfaceCompletion     CompletionItemKind = 8
+	ModuleCompletion        CompletionItemKind = 9
+	PropertyCompletion      CompletionItemKind = 10
+	UnitCompletion          CompletionItemKind = 11
+	ValueCompletion         CompletionItemKind = 12
+	EnumCompletion          CompletionItemKind = 13
+	KeywordCompletion       CompletionItemKind = 14
+	SnippetCompletion       CompletionItemKind = 15
+	ColorCompletion         CompletionItemKind = 16
+	FileCompletion          CompletionItemKind = 17
+	ReferenceCompletion     CompletionItemKind = 18
+	FolderCompletion        CompletionItemKind = 19
+	EnumMemberCompletion    CompletionItemKind = 20
+	ConstantCompletion      CompletionItemKind = 21
+	StructCompletion        CompletionItemKind = 22
+	EventCompletion         CompletionItemKind = 23
+	OperatorCompletion      CompletionItemKind = 24
+	TypeParameterCompletion CompletionItemKind = 25
 	// Completion item tags are extra annotations that tweak the rendering of a completion
 	// item.
 	//
 	// @since 3.15.0
 	// Render a completion as obsolete, usually using a strike-out.
-	ComplDeprecated CompletionItemTag = 1 // line 13251
+	ComplDeprecated CompletionItemTag = 1
 	// How a completion was triggered
 	// Completion was triggered by typing an identifier (24x7 code
 	// complete), manual invocation (e.g Ctrl+Space) or via API.
-	Invoked CompletionTriggerKind = 1 // line 13562
+	Invoked CompletionTriggerKind = 1
 	// Completion was triggered by a trigger character specified by
 	// the `triggerCharacters` properties of the `CompletionRegistrationOptions`.
-	TriggerCharacter CompletionTriggerKind = 2 // line 13567
+	TriggerCharacter CompletionTriggerKind = 2
 	// Completion was re-triggered as current completion list is incomplete
-	TriggerForIncompleteCompletions CompletionTriggerKind = 3 // line 13572
+	TriggerForIncompleteCompletions CompletionTriggerKind = 3
 	// The diagnostic's severity.
 	// Reports an error.
-	SeverityError DiagnosticSeverity = 1 // line 13511
+	SeverityError DiagnosticSeverity = 1
 	// Reports a warning.
-	SeverityWarning DiagnosticSeverity = 2 // line 13516
+	SeverityWarning DiagnosticSeverity = 2
 	// Reports an information.
-	SeverityInformation DiagnosticSeverity = 3 // line 13521
+	SeverityInformation DiagnosticSeverity = 3
 	// Reports a hint.
-	SeverityHint DiagnosticSeverity = 4 // line 13526
+	SeverityHint DiagnosticSeverity = 4
 	// The diagnostic tags.
 	//
 	// @since 3.15.0
@@ -5131,83 +5446,91 @@ const (
 	//
 	// Clients are allowed to render diagnostics with this tag faded out instead of having
 	// an error squiggle.
-	Unnecessary DiagnosticTag = 1 // line 13541
+	Unnecessary DiagnosticTag = 1
 	// Deprecated or obsolete code.
 	//
 	// Clients are allowed to rendered diagnostics with this tag strike through.
-	Deprecated DiagnosticTag = 2 // line 13546
+	Deprecated DiagnosticTag = 2
 	// The document diagnostic report kinds.
 	//
 	// @since 3.17.0
 	// A diagnostic report with a full
 	// set of problems.
-	DiagnosticFull DocumentDiagnosticReportKind = "full" // line 12729
+	DiagnosticFull DocumentDiagnosticReportKind = "full"
 	// A report indicating that the last
 	// returned report is still accurate.
-	DiagnosticUnchanged DocumentDiagnosticReportKind = "unchanged" // line 12734
+	DiagnosticUnchanged DocumentDiagnosticReportKind = "unchanged"
 	// A document highlight kind.
 	// A textual occurrence.
-	Text DocumentHighlightKind = 1 // line 13308
+	Text DocumentHighlightKind = 1
 	// Read-access of a symbol, like reading a variable.
-	Read DocumentHighlightKind = 2 // line 13313
+	Read DocumentHighlightKind = 2
 	// Write-access of a symbol, like writing to a variable.
-	Write DocumentHighlightKind = 3 // line 13318
+	Write DocumentHighlightKind = 3
 	// Predefined error codes.
-	ParseError     ErrorCodes = -32700 // line 12750
-	InvalidRequest ErrorCodes = -32600 // line 12754
-	MethodNotFound ErrorCodes = -32601 // line 12758
-	InvalidParams  ErrorCodes = -32602 // line 12762
-	InternalError  ErrorCodes = -32603 // line 12766
+	ParseError     ErrorCodes = -32700
+	InvalidRequest ErrorCodes = -32600
+	MethodNotFound ErrorCodes = -32601
+	InvalidParams  ErrorCodes = -32602
+	InternalError  ErrorCodes = -32603
 	// Error code indicating that a server received a notification or
 	// request before the server has received the `initialize` request.
-	ServerNotInitialized ErrorCodes = -32002 // line 12770
-	UnknownErrorCode     ErrorCodes = -32001 // line 12775
+	ServerNotInitialized ErrorCodes = -32002
+	UnknownErrorCode     ErrorCodes = -32001
 	// Applying the workspace change is simply aborted if one of the changes provided
 	// fails. All operations executed before the failing operation stay executed.
-	Abort FailureHandlingKind = "abort" // line 13700
+	Abort FailureHandlingKind = "abort"
 	// All operations are executed transactional. That means they either all
 	// succeed or no changes at all are applied to the workspace.
-	Transactional FailureHandlingKind = "transactional" // line 13705
+	Transactional FailureHandlingKind = "transactional"
 	// If the workspace edit contains only textual file changes they are executed transactional.
 	// If resource changes (create, rename or delete file) are part of the change the failure
 	// handling strategy is abort.
-	TextOnlyTransactional FailureHandlingKind = "textOnlyTransactional" // line 13710
+	TextOnlyTransactional FailureHandlingKind = "textOnlyTransactional"
 	// The client tries to undo the operations already executed. But there is no
 	// guarantee that this is succeeding.
-	Undo FailureHandlingKind = "undo" // line 13715
+	Undo FailureHandlingKind = "undo"
 	// The file event type
 	// The file got created.
-	Created FileChangeType = 1 // line 13461
+	Created FileChangeType = 1
 	// The file got changed.
-	Changed FileChangeType = 2 // line 13466
+	Changed FileChangeType = 2
 	// The file got deleted.
-	Deleted FileChangeType = 3 // line 13471
+	Deleted FileChangeType = 3
 	// A pattern kind describing if a glob pattern matches a file a folder or
 	// both.
 	//
 	// @since 3.16.0
 	// The pattern matches a file only.
-	FilePattern FileOperationPatternKind = "file" // line 13634
+	FilePattern FileOperationPatternKind = "file"
 	// The pattern matches a folder only.
-	FolderPattern FileOperationPatternKind = "folder" // line 13639
+	FolderPattern FileOperationPatternKind = "folder"
 	// A set of predefined range kinds.
 	// Folding range for a comment
-	Comment FoldingRangeKind = "comment" // line 12822
+	Comment FoldingRangeKind = "comment"
 	// Folding range for an import or include
-	Imports FoldingRangeKind = "imports" // line 12827
+	Imports FoldingRangeKind = "imports"
 	// Folding range for a region (e.g. `#region`)
-	Region FoldingRangeKind = "region" // line 12832
+	Region FoldingRangeKind = "region"
 	// Inlay hint kinds.
 	//
 	// @since 3.17.0
 	// An inlay hint that for a type annotation.
-	Type InlayHintKind = 1 // line 13040
+	Type InlayHintKind = 1
 	// An inlay hint that is for a parameter.
-	Parameter InlayHintKind = 2 // line 13045
+	Parameter InlayHintKind = 2
+	// Describes how an {@link InlineCompletionItemProvider inline completion provider} was triggered.
+	//
+	// @since 3.18.0
+	// @proposed
+	// Completion was triggered explicitly by a user gesture.
+	InlineInvoked InlineCompletionTriggerKind = 0
+	// Completion was triggered automatically while editing.
+	InlineAutomatic InlineCompletionTriggerKind = 1
 	// Defines whether the insert text in a completion item should be interpreted as
 	// plain text or a snippet.
 	// The primary text to be inserted is treated as a plain string.
-	PlainTextTextFormat InsertTextFormat = 1 // line 13267
+	PlainTextTextFormat InsertTextFormat = 1
 	// The primary text to be inserted is treated as a snippet.
 	//
 	// A snippet can define tab stops and placeholders with `$1`, `$2`
@@ -5216,7 +5539,7 @@ const (
 	// that is typing in one will update others too.
 	//
 	// See also: https://microsoft.github.io/language-server-protocol/specifications/specification-current/#snippet_syntax
-	SnippetTextFormat InsertTextFormat = 2 // line 13272
+	SnippetTextFormat InsertTextFormat = 2
 	// How whitespace and indentation is handled during completion
 	// item insertion.
 	//
@@ -5226,7 +5549,7 @@ const (
 	// inserted using the indentation defined in the string value.
 	// The client will not apply any kind of adjustments to the
 	// string.
-	AsIs InsertTextMode = 1 // line 13287
+	AsIs InsertTextMode = 1
 	// The editor adjusts leading whitespace of new lines so that
 	// they match the indentation up to the cursor of the line for
 	// which the item is accepted.
@@ -5234,20 +5557,20 @@ const (
 	// Consider a line like this: <2tabs><cursor><3tabs>foo. Accepting a
 	// multi line completion item is indented using 2 tabs and all
 	// following lines inserted will be indented using 2 tabs as well.
-	AdjustIndentation InsertTextMode = 2 // line 13292
+	AdjustIndentation InsertTextMode = 2
 	// A request failed but it was syntactically correct, e.g the
 	// method name was known and the parameters were valid. The error
 	// message should contain human readable information about why
 	// the request failed.
 	//
 	// @since 3.17.0
-	RequestFailed LSPErrorCodes = -32803 // line 12790
+	RequestFailed LSPErrorCodes = -32803
 	// The server cancelled the request. This error code should
 	// only be used for requests that explicitly support being
 	// server cancellable.
 	//
 	// @since 3.17.0
-	ServerCancelled LSPErrorCodes = -32802 // line 12796
+	ServerCancelled LSPErrorCodes = -32802
 	// The server detected that the content of a document got
 	// modified outside normal conditions. A server should
 	// NOT send this error code if it detects a content change
@@ -5256,200 +5579,204 @@ const (
 	//
 	// If a client decides that a result is not of any use anymore
 	// the client should cancel the request.
-	ContentModified LSPErrorCodes = -32801 // line 12802
+	ContentModified LSPErrorCodes = -32801
 	// The client has canceled a request and a server as detected
 	// the cancel.
-	RequestCancelled LSPErrorCodes = -32800 // line 12807
+	RequestCancelled LSPErrorCodes = -32800
 	// Describes the content type that a client supports in various
 	// result literals like `Hover`, `ParameterInfo` or `CompletionItem`.
 	//
 	// Please note that `MarkupKinds` must not start with a `$`. This kinds
 	// are reserved for internal usage.
 	// Plain text is supported as a content format
-	PlainText MarkupKind = "plaintext" // line 13414
+	PlainText MarkupKind = "plaintext"
 	// Markdown is supported as a content format
-	Markdown MarkupKind = "markdown" // line 13419
+	Markdown MarkupKind = "markdown"
 	// The message type
 	// An error message.
-	Error MessageType = 1 // line 13061
+	Error MessageType = 1
 	// A warning message.
-	Warning MessageType = 2 // line 13066
+	Warning MessageType = 2
 	// An information message.
-	Info MessageType = 3 // line 13071
+	Info MessageType = 3
 	// A log message.
-	Log MessageType = 4 // line 13076
+	Log MessageType = 4
+	// A debug message.
+	//
+	// @since 3.18.0
+	Debug MessageType = 5
 	// The moniker kind.
 	//
 	// @since 3.16.0
 	// The moniker represent a symbol that is imported into a project
-	Import MonikerKind = "import" // line 13014
+	Import MonikerKind = "import"
 	// The moniker represents a symbol that is exported from a project
-	Export MonikerKind = "export" // line 13019
+	Export MonikerKind = "export"
 	// The moniker represents a symbol that is local to a project (e.g. a local
 	// variable of a function, a class not visible outside the project, ...)
-	Local MonikerKind = "local" // line 13024
+	Local MonikerKind = "local"
 	// A notebook cell kind.
 	//
 	// @since 3.17.0
 	// A markup-cell is formatted source that is used for display.
-	Markup NotebookCellKind = 1 // line 13655
+	Markup NotebookCellKind = 1
 	// A code-cell is source code.
-	Code NotebookCellKind = 2 // line 13660
+	Code NotebookCellKind = 2
 	// A set of predefined position encoding kinds.
 	//
 	// @since 3.17.0
-	// Character offsets count UTF-8 code units.
-	UTF8 PositionEncodingKind = "utf-8" // line 13434
+	// Character offsets count UTF-8 code units (e.g. bytes).
+	UTF8 PositionEncodingKind = "utf-8"
 	// Character offsets count UTF-16 code units.
 	//
 	// This is the default and must always be supported
 	// by servers
-	UTF16 PositionEncodingKind = "utf-16" // line 13439
+	UTF16 PositionEncodingKind = "utf-16"
 	// Character offsets count UTF-32 code units.
 	//
-	// Implementation note: these are the same as Unicode code points,
+	// Implementation note: these are the same as Unicode codepoints,
 	// so this `PositionEncodingKind` may also be used for an
 	// encoding-agnostic representation of character offsets.
-	UTF32 PositionEncodingKind = "utf-32" // line 13444
+	UTF32 PositionEncodingKind = "utf-32"
 	// The client's default behavior is to select the identifier
 	// according the to language's syntax rule.
-	Identifier PrepareSupportDefaultBehavior = 1 // line 13729
+	Identifier PrepareSupportDefaultBehavior = 1
 	// Supports creating new files and folders.
-	Create ResourceOperationKind = "create" // line 13676
+	Create ResourceOperationKind = "create"
 	// Supports renaming existing files and folders.
-	Rename ResourceOperationKind = "rename" // line 13681
+	Rename ResourceOperationKind = "rename"
 	// Supports deleting existing files and folders.
-	Delete ResourceOperationKind = "delete" // line 13686
+	Delete ResourceOperationKind = "delete"
 	// A set of predefined token modifiers. This set is not fixed
 	// an clients can specify additional token types via the
 	// corresponding client capabilities.
 	//
 	// @since 3.16.0
-	ModDeclaration    SemanticTokenModifiers = "declaration"    // line 12677
-	ModDefinition     SemanticTokenModifiers = "definition"     // line 12681
-	ModReadonly       SemanticTokenModifiers = "readonly"       // line 12685
-	ModStatic         SemanticTokenModifiers = "static"         // line 12689
-	ModDeprecated     SemanticTokenModifiers = "deprecated"     // line 12693
-	ModAbstract       SemanticTokenModifiers = "abstract"       // line 12697
-	ModAsync          SemanticTokenModifiers = "async"          // line 12701
-	ModModification   SemanticTokenModifiers = "modification"   // line 12705
-	ModDocumentation  SemanticTokenModifiers = "documentation"  // line 12709
-	ModDefaultLibrary SemanticTokenModifiers = "defaultLibrary" // line 12713
+	ModDeclaration    SemanticTokenModifiers = "declaration"
+	ModDefinition     SemanticTokenModifiers = "definition"
+	ModReadonly       SemanticTokenModifiers = "readonly"
+	ModStatic         SemanticTokenModifiers = "static"
+	ModDeprecated     SemanticTokenModifiers = "deprecated"
+	ModAbstract       SemanticTokenModifiers = "abstract"
+	ModAsync          SemanticTokenModifiers = "async"
+	ModModification   SemanticTokenModifiers = "modification"
+	ModDocumentation  SemanticTokenModifiers = "documentation"
+	ModDefaultLibrary SemanticTokenModifiers = "defaultLibrary"
 	// A set of predefined token types. This set is not fixed
 	// an clients can specify additional token types via the
 	// corresponding client capabilities.
 	//
 	// @since 3.16.0
-	NamespaceType SemanticTokenTypes = "namespace" // line 12570
+	NamespaceType SemanticTokenTypes = "namespace"
 	// Represents a generic type. Acts as a fallback for types which can't be mapped to
 	// a specific type like class or enum.
-	TypeType          SemanticTokenTypes = "type"          // line 12574
-	ClassType         SemanticTokenTypes = "class"         // line 12579
-	EnumType          SemanticTokenTypes = "enum"          // line 12583
-	InterfaceType     SemanticTokenTypes = "interface"     // line 12587
-	StructType        SemanticTokenTypes = "struct"        // line 12591
-	TypeParameterType SemanticTokenTypes = "typeParameter" // line 12595
-	ParameterType     SemanticTokenTypes = "parameter"     // line 12599
-	VariableType      SemanticTokenTypes = "variable"      // line 12603
-	PropertyType      SemanticTokenTypes = "property"      // line 12607
-	EnumMemberType    SemanticTokenTypes = "enumMember"    // line 12611
-	EventType         SemanticTokenTypes = "event"         // line 12615
-	FunctionType      SemanticTokenTypes = "function"      // line 12619
-	MethodType        SemanticTokenTypes = "method"        // line 12623
-	MacroType         SemanticTokenTypes = "macro"         // line 12627
-	KeywordType       SemanticTokenTypes = "keyword"       // line 12631
-	ModifierType      SemanticTokenTypes = "modifier"      // line 12635
-	CommentType       SemanticTokenTypes = "comment"       // line 12639
-	StringType        SemanticTokenTypes = "string"        // line 12643
-	NumberType        SemanticTokenTypes = "number"        // line 12647
-	RegexpType        SemanticTokenTypes = "regexp"        // line 12651
-	OperatorType      SemanticTokenTypes = "operator"      // line 12655
+	TypeType          SemanticTokenTypes = "type"
+	ClassType         SemanticTokenTypes = "class"
+	EnumType          SemanticTokenTypes = "enum"
+	InterfaceType     SemanticTokenTypes = "interface"
+	StructType        SemanticTokenTypes = "struct"
+	TypeParameterType SemanticTokenTypes = "typeParameter"
+	ParameterType     SemanticTokenTypes = "parameter"
+	VariableType      SemanticTokenTypes = "variable"
+	PropertyType      SemanticTokenTypes = "property"
+	EnumMemberType    SemanticTokenTypes = "enumMember"
+	EventType         SemanticTokenTypes = "event"
+	FunctionType      SemanticTokenTypes = "function"
+	MethodType        SemanticTokenTypes = "method"
+	MacroType         SemanticTokenTypes = "macro"
+	KeywordType       SemanticTokenTypes = "keyword"
+	ModifierType      SemanticTokenTypes = "modifier"
+	CommentType       SemanticTokenTypes = "comment"
+	StringType        SemanticTokenTypes = "string"
+	NumberType        SemanticTokenTypes = "number"
+	RegexpType        SemanticTokenTypes = "regexp"
+	OperatorType      SemanticTokenTypes = "operator"
 	// @since 3.17.0
-	DecoratorType SemanticTokenTypes = "decorator" // line 12659
+	DecoratorType SemanticTokenTypes = "decorator"
 	// How a signature help was triggered.
 	//
 	// @since 3.15.0
 	// Signature help was invoked manually by the user or by a command.
-	SigInvoked SignatureHelpTriggerKind = 1 // line 13587
+	SigInvoked SignatureHelpTriggerKind = 1
 	// Signature help was triggered by a trigger character.
-	SigTriggerCharacter SignatureHelpTriggerKind = 2 // line 13592
+	SigTriggerCharacter SignatureHelpTriggerKind = 2
 	// Signature help was triggered by the cursor moving or by the document content changing.
-	SigContentChange SignatureHelpTriggerKind = 3 // line 13597
+	SigContentChange SignatureHelpTriggerKind = 3
 	// A symbol kind.
-	File          SymbolKind = 1  // line 12848
-	Module        SymbolKind = 2  // line 12852
-	Namespace     SymbolKind = 3  // line 12856
-	Package       SymbolKind = 4  // line 12860
-	Class         SymbolKind = 5  // line 12864
-	Method        SymbolKind = 6  // line 12868
-	Property      SymbolKind = 7  // line 12872
-	Field         SymbolKind = 8  // line 12876
-	Constructor   SymbolKind = 9  // line 12880
-	Enum          SymbolKind = 10 // line 12884
-	Interface     SymbolKind = 11 // line 12888
-	Function      SymbolKind = 12 // line 12892
-	Variable      SymbolKind = 13 // line 12896
-	Constant      SymbolKind = 14 // line 12900
-	String        SymbolKind = 15 // line 12904
-	Number        SymbolKind = 16 // line 12908
-	Boolean       SymbolKind = 17 // line 12912
-	Array         SymbolKind = 18 // line 12916
-	Object        SymbolKind = 19 // line 12920
-	Key           SymbolKind = 20 // line 12924
-	Null          SymbolKind = 21 // line 12928
-	EnumMember    SymbolKind = 22 // line 12932
-	Struct        SymbolKind = 23 // line 12936
-	Event         SymbolKind = 24 // line 12940
-	Operator      SymbolKind = 25 // line 12944
-	TypeParameter SymbolKind = 26 // line 12948
+	File          SymbolKind = 1
+	Module        SymbolKind = 2
+	Namespace     SymbolKind = 3
+	Package       SymbolKind = 4
+	Class         SymbolKind = 5
+	Method        SymbolKind = 6
+	Property      SymbolKind = 7
+	Field         SymbolKind = 8
+	Constructor   SymbolKind = 9
+	Enum          SymbolKind = 10
+	Interface     SymbolKind = 11
+	Function      SymbolKind = 12
+	Variable      SymbolKind = 13
+	Constant      SymbolKind = 14
+	String        SymbolKind = 15
+	Number        SymbolKind = 16
+	Boolean       SymbolKind = 17
+	Array         SymbolKind = 18
+	Object        SymbolKind = 19
+	Key           SymbolKind = 20
+	Null          SymbolKind = 21
+	EnumMember    SymbolKind = 22
+	Struct        SymbolKind = 23
+	Event         SymbolKind = 24
+	Operator      SymbolKind = 25
+	TypeParameter SymbolKind = 26
 	// Symbol tags are extra annotations that tweak the rendering of a symbol.
 	//
 	// @since 3.16
 	// Render a symbol as obsolete, usually using a strike-out.
-	DeprecatedSymbol SymbolTag = 1 // line 12962
+	DeprecatedSymbol SymbolTag = 1
 	// Represents reasons why a text document is saved.
 	// Manually triggered, e.g. by the user pressing save, by starting debugging,
 	// or by an API call.
-	Manual TextDocumentSaveReason = 1 // line 13116
+	Manual TextDocumentSaveReason = 1
 	// Automatic after a delay.
-	AfterDelay TextDocumentSaveReason = 2 // line 13121
+	AfterDelay TextDocumentSaveReason = 2
 	// When the editor lost focus.
-	FocusOut TextDocumentSaveReason = 3 // line 13126
+	FocusOut TextDocumentSaveReason = 3
 	// Defines how the host (editor) should sync
 	// document changes to the language server.
 	// Documents should not be synced at all.
-	None TextDocumentSyncKind = 0 // line 13091
+	None TextDocumentSyncKind = 0
 	// Documents are synced by always sending the full content
 	// of the document.
-	Full TextDocumentSyncKind = 1 // line 13096
+	Full TextDocumentSyncKind = 1
 	// Documents are synced by sending the full content on open.
 	// After that only incremental updates to the document are
 	// send.
-	Incremental TextDocumentSyncKind = 2          // line 13101
-	Relative    TokenFormat          = "relative" // line 13743
+	Incremental TextDocumentSyncKind = 2
+	Relative    TokenFormat          = "relative"
 	// Turn tracing off.
-	Off TraceValues = "off" // line 13390
+	Off TraceValues = "off"
 	// Trace messages only.
-	Messages TraceValues = "messages" // line 13395
+	Messages TraceValues = "messages"
 	// Verbose message tracing.
-	Verbose TraceValues = "verbose" // line 13400
+	Verbose TraceValues = "verbose"
 	// Moniker uniqueness level to define scope of the moniker.
 	//
 	// @since 3.16.0
 	// The moniker is only unique inside a document
-	Document UniquenessLevel = "document" // line 12978
+	Document UniquenessLevel = "document"
 	// The moniker is unique inside a project for which a dump got created
-	Project UniquenessLevel = "project" // line 12983
+	Project UniquenessLevel = "project"
 	// The moniker is unique inside the group to which a project belongs
-	Group UniquenessLevel = "group" // line 12988
+	Group UniquenessLevel = "group"
 	// The moniker is unique inside the moniker scheme.
-	Scheme UniquenessLevel = "scheme" // line 12993
+	Scheme UniquenessLevel = "scheme"
 	// The moniker is globally unique
-	Global UniquenessLevel = "global" // line 12998
+	Global UniquenessLevel = "global"
 	// Interested in create events.
-	WatchCreate WatchKind = 1 // line 13486
+	WatchCreate WatchKind = 1
 	// Interested in change events
-	WatchChange WatchKind = 2 // line 13491
+	WatchChange WatchKind = 2
 	// Interested in delete events
-	WatchDelete WatchKind = 4 // line 13496
+	WatchDelete WatchKind = 4
 )

--- a/lsp/protocol/tsserver.go
+++ b/lsp/protocol/tsserver.go
@@ -6,8 +6,8 @@
 
 package protocol
 
-// Code generated from protocol/metaModel.json at ref release/protocol/3.17.4-next.0 (hash 5c6ec4f537f304aa1ad645b5fd2bbb757fc40ed1).
-// https://github.com/microsoft/vscode-languageserver-node/blob/release/protocol/3.17.4-next.0/protocol/metaModel.json
+// Code generated from protocol/metaModel.json at ref release/protocol/3.17.6-next.1 (hash d2c907f450cb6d3baff74b31b432b90786d2c3b0).
+// https://github.com/microsoft/vscode-languageserver-node/blob/release/protocol/3.17.6-next.1/protocol/metaModel.json
 // LSP metaData.version = 3.17.0.
 
 import (
@@ -18,78 +18,80 @@ import (
 )
 
 type Server interface {
-	Progress(context.Context, *ProgressParams) error                                                       // $/progress
-	SetTrace(context.Context, *SetTraceParams) error                                                       // $/setTrace
-	IncomingCalls(context.Context, *CallHierarchyIncomingCallsParams) ([]CallHierarchyIncomingCall, error) // callHierarchy/incomingCalls
-	OutgoingCalls(context.Context, *CallHierarchyOutgoingCallsParams) ([]CallHierarchyOutgoingCall, error) // callHierarchy/outgoingCalls
-	ResolveCodeAction(context.Context, *CodeAction) (*CodeAction, error)                                   // codeAction/resolve
-	ResolveCodeLens(context.Context, *CodeLens) (*CodeLens, error)                                         // codeLens/resolve
-	ResolveCompletionItem(context.Context, *CompletionItem) (*CompletionItem, error)                       // completionItem/resolve
-	ResolveDocumentLink(context.Context, *DocumentLink) (*DocumentLink, error)                             // documentLink/resolve
-	Exit(context.Context) error                                                                            // exit
-	Initialize(context.Context, *ParamInitialize) (*InitializeResult, error)                               // initialize
-	Initialized(context.Context, *InitializedParams) error                                                 // initialized
-	Resolve(context.Context, *InlayHint) (*InlayHint, error)                                               // inlayHint/resolve
-	DidChangeNotebookDocument(context.Context, *DidChangeNotebookDocumentParams) error                     // notebookDocument/didChange
-	DidCloseNotebookDocument(context.Context, *DidCloseNotebookDocumentParams) error                       // notebookDocument/didClose
-	DidOpenNotebookDocument(context.Context, *DidOpenNotebookDocumentParams) error                         // notebookDocument/didOpen
-	DidSaveNotebookDocument(context.Context, *DidSaveNotebookDocumentParams) error                         // notebookDocument/didSave
-	Shutdown(context.Context) error                                                                        // shutdown
-	CodeAction(context.Context, *CodeActionParams) ([]CodeAction, error)                                   // textDocument/codeAction
-	CodeLens(context.Context, *CodeLensParams) ([]CodeLens, error)                                         // textDocument/codeLens
-	ColorPresentation(context.Context, *ColorPresentationParams) ([]ColorPresentation, error)              // textDocument/colorPresentation
-	Completion(context.Context, *CompletionParams) (*CompletionList, error)                                // textDocument/completion
-	Declaration(context.Context, *DeclarationParams) (*Or_textDocument_declaration, error)                 // textDocument/declaration
-	Definition(context.Context, *DefinitionParams) ([]Location, error)                                     // textDocument/definition
-	Diagnostic(context.Context, *string) (*string, error)                                                  // textDocument/diagnostic
-	DidChange(context.Context, *DidChangeTextDocumentParams) error                                         // textDocument/didChange
-	DidClose(context.Context, *DidCloseTextDocumentParams) error                                           // textDocument/didClose
-	DidOpen(context.Context, *DidOpenTextDocumentParams) error                                             // textDocument/didOpen
-	DidSave(context.Context, *DidSaveTextDocumentParams) error                                             // textDocument/didSave
-	DocumentColor(context.Context, *DocumentColorParams) ([]ColorInformation, error)                       // textDocument/documentColor
-	DocumentHighlight(context.Context, *DocumentHighlightParams) ([]DocumentHighlight, error)              // textDocument/documentHighlight
-	DocumentLink(context.Context, *DocumentLinkParams) ([]DocumentLink, error)                             // textDocument/documentLink
-	DocumentSymbol(context.Context, *DocumentSymbolParams) ([]interface{}, error)                          // textDocument/documentSymbol
-	FoldingRange(context.Context, *FoldingRangeParams) ([]FoldingRange, error)                             // textDocument/foldingRange
-	Formatting(context.Context, *DocumentFormattingParams) ([]TextEdit, error)                             // textDocument/formatting
-	Hover(context.Context, *HoverParams) (*Hover, error)                                                   // textDocument/hover
-	Implementation(context.Context, *ImplementationParams) ([]Location, error)                             // textDocument/implementation
-	InlayHint(context.Context, *InlayHintParams) ([]InlayHint, error)                                      // textDocument/inlayHint
-	InlineValue(context.Context, *InlineValueParams) ([]InlineValue, error)                                // textDocument/inlineValue
-	LinkedEditingRange(context.Context, *LinkedEditingRangeParams) (*LinkedEditingRanges, error)           // textDocument/linkedEditingRange
-	Moniker(context.Context, *MonikerParams) ([]Moniker, error)                                            // textDocument/moniker
-	OnTypeFormatting(context.Context, *DocumentOnTypeFormattingParams) ([]TextEdit, error)                 // textDocument/onTypeFormatting
-	PrepareCallHierarchy(context.Context, *CallHierarchyPrepareParams) ([]CallHierarchyItem, error)        // textDocument/prepareCallHierarchy
-	PrepareRename(context.Context, *PrepareRenameParams) (*PrepareRename2Gn, error)                        // textDocument/prepareRename
-	PrepareTypeHierarchy(context.Context, *TypeHierarchyPrepareParams) ([]TypeHierarchyItem, error)        // textDocument/prepareTypeHierarchy
-	RangeFormatting(context.Context, *DocumentRangeFormattingParams) ([]TextEdit, error)                   // textDocument/rangeFormatting
-	References(context.Context, *ReferenceParams) ([]Location, error)                                      // textDocument/references
-	Rename(context.Context, *RenameParams) (*WorkspaceEdit, error)                                         // textDocument/rename
-	SelectionRange(context.Context, *SelectionRangeParams) ([]SelectionRange, error)                       // textDocument/selectionRange
-	SemanticTokensFull(context.Context, *SemanticTokensParams) (*SemanticTokens, error)                    // textDocument/semanticTokens/full
-	SemanticTokensFullDelta(context.Context, *SemanticTokensDeltaParams) (interface{}, error)              // textDocument/semanticTokens/full/delta
-	SemanticTokensRange(context.Context, *SemanticTokensRangeParams) (*SemanticTokens, error)              // textDocument/semanticTokens/range
-	SignatureHelp(context.Context, *SignatureHelpParams) (*SignatureHelp, error)                           // textDocument/signatureHelp
-	TypeDefinition(context.Context, *TypeDefinitionParams) ([]Location, error)                             // textDocument/typeDefinition
-	WillSave(context.Context, *WillSaveTextDocumentParams) error                                           // textDocument/willSave
-	WillSaveWaitUntil(context.Context, *WillSaveTextDocumentParams) ([]TextEdit, error)                    // textDocument/willSaveWaitUntil
-	Subtypes(context.Context, *TypeHierarchySubtypesParams) ([]TypeHierarchyItem, error)                   // typeHierarchy/subtypes
-	Supertypes(context.Context, *TypeHierarchySupertypesParams) ([]TypeHierarchyItem, error)               // typeHierarchy/supertypes
-	WorkDoneProgressCancel(context.Context, *WorkDoneProgressCancelParams) error                           // window/workDoneProgress/cancel
-	DiagnosticWorkspace(context.Context, *WorkspaceDiagnosticParams) (*WorkspaceDiagnosticReport, error)   // workspace/diagnostic
-	DidChangeConfiguration(context.Context, *DidChangeConfigurationParams) error                           // workspace/didChangeConfiguration
-	DidChangeWatchedFiles(context.Context, *DidChangeWatchedFilesParams) error                             // workspace/didChangeWatchedFiles
-	DidChangeWorkspaceFolders(context.Context, *DidChangeWorkspaceFoldersParams) error                     // workspace/didChangeWorkspaceFolders
-	DidCreateFiles(context.Context, *CreateFilesParams) error                                              // workspace/didCreateFiles
-	DidDeleteFiles(context.Context, *DeleteFilesParams) error                                              // workspace/didDeleteFiles
-	DidRenameFiles(context.Context, *RenameFilesParams) error                                              // workspace/didRenameFiles
-	ExecuteCommand(context.Context, *ExecuteCommandParams) (interface{}, error)                            // workspace/executeCommand
-	Symbol(context.Context, *WorkspaceSymbolParams) ([]SymbolInformation, error)                           // workspace/symbol
-	WillCreateFiles(context.Context, *CreateFilesParams) (*WorkspaceEdit, error)                           // workspace/willCreateFiles
-	WillDeleteFiles(context.Context, *DeleteFilesParams) (*WorkspaceEdit, error)                           // workspace/willDeleteFiles
-	WillRenameFiles(context.Context, *RenameFilesParams) (*WorkspaceEdit, error)                           // workspace/willRenameFiles
-	ResolveWorkspaceSymbol(context.Context, *WorkspaceSymbol) (*WorkspaceSymbol, error)                    // workspaceSymbol/resolve
-	NonstandardRequest(ctx context.Context, method string, params interface{}) (interface{}, error)
+	Progress(context.Context, *ProgressParams) error                                                             // $/progress
+	SetTrace(context.Context, *SetTraceParams) error                                                             // $/setTrace
+	IncomingCalls(context.Context, *CallHierarchyIncomingCallsParams) ([]CallHierarchyIncomingCall, error)       // callHierarchy/incomingCalls
+	OutgoingCalls(context.Context, *CallHierarchyOutgoingCallsParams) ([]CallHierarchyOutgoingCall, error)       // callHierarchy/outgoingCalls
+	ResolveCodeAction(context.Context, *CodeAction) (*CodeAction, error)                                         // codeAction/resolve
+	ResolveCodeLens(context.Context, *CodeLens) (*CodeLens, error)                                               // codeLens/resolve
+	ResolveCompletionItem(context.Context, *CompletionItem) (*CompletionItem, error)                             // completionItem/resolve
+	ResolveDocumentLink(context.Context, *DocumentLink) (*DocumentLink, error)                                   // documentLink/resolve
+	Exit(context.Context) error                                                                                  // exit
+	Initialize(context.Context, *ParamInitialize) (*InitializeResult, error)                                     // initialize
+	Initialized(context.Context, *InitializedParams) error                                                       // initialized
+	Resolve(context.Context, *InlayHint) (*InlayHint, error)                                                     // inlayHint/resolve
+	DidChangeNotebookDocument(context.Context, *DidChangeNotebookDocumentParams) error                           // notebookDocument/didChange
+	DidCloseNotebookDocument(context.Context, *DidCloseNotebookDocumentParams) error                             // notebookDocument/didClose
+	DidOpenNotebookDocument(context.Context, *DidOpenNotebookDocumentParams) error                               // notebookDocument/didOpen
+	DidSaveNotebookDocument(context.Context, *DidSaveNotebookDocumentParams) error                               // notebookDocument/didSave
+	Shutdown(context.Context) error                                                                              // shutdown
+	CodeAction(context.Context, *CodeActionParams) ([]CodeAction, error)                                         // textDocument/codeAction
+	CodeLens(context.Context, *CodeLensParams) ([]CodeLens, error)                                               // textDocument/codeLens
+	ColorPresentation(context.Context, *ColorPresentationParams) ([]ColorPresentation, error)                    // textDocument/colorPresentation
+	Completion(context.Context, *CompletionParams) (*Or_Result_textDocument_completion, error)                   // textDocument/completion
+	Declaration(context.Context, *DeclarationParams) (*Or_textDocument_declaration, error)                       // textDocument/declaration
+	Definition(context.Context, *DefinitionParams) (*Or_Result_textDocument_definition, error)                   // textDocument/definition
+	Diagnostic(context.Context, *string) (*string, error)                                                        // textDocument/diagnostic
+	DidChange(context.Context, *DidChangeTextDocumentParams) error                                               // textDocument/didChange
+	DidClose(context.Context, *DidCloseTextDocumentParams) error                                                 // textDocument/didClose
+	DidOpen(context.Context, *DidOpenTextDocumentParams) error                                                   // textDocument/didOpen
+	DidSave(context.Context, *DidSaveTextDocumentParams) error                                                   // textDocument/didSave
+	DocumentColor(context.Context, *DocumentColorParams) ([]ColorInformation, error)                             // textDocument/documentColor
+	DocumentHighlight(context.Context, *DocumentHighlightParams) ([]DocumentHighlight, error)                    // textDocument/documentHighlight
+	DocumentLink(context.Context, *DocumentLinkParams) ([]DocumentLink, error)                                   // textDocument/documentLink
+	DocumentSymbol(context.Context, *DocumentSymbolParams) ([]interface{}, error)                                // textDocument/documentSymbol
+	FoldingRange(context.Context, *FoldingRangeParams) ([]FoldingRange, error)                                   // textDocument/foldingRange
+	Formatting(context.Context, *DocumentFormattingParams) ([]TextEdit, error)                                   // textDocument/formatting
+	Hover(context.Context, *HoverParams) (*Hover, error)                                                         // textDocument/hover
+	Implementation(context.Context, *ImplementationParams) ([]Location, error)                                   // textDocument/implementation
+	InlayHint(context.Context, *InlayHintParams) ([]InlayHint, error)                                            // textDocument/inlayHint
+	InlineCompletion(context.Context, *InlineCompletionParams) (*Or_Result_textDocument_inlineCompletion, error) // textDocument/inlineCompletion
+	InlineValue(context.Context, *InlineValueParams) ([]InlineValue, error)                                      // textDocument/inlineValue
+	LinkedEditingRange(context.Context, *LinkedEditingRangeParams) (*LinkedEditingRanges, error)                 // textDocument/linkedEditingRange
+	Moniker(context.Context, *MonikerParams) ([]Moniker, error)                                                  // textDocument/moniker
+	OnTypeFormatting(context.Context, *DocumentOnTypeFormattingParams) ([]TextEdit, error)                       // textDocument/onTypeFormatting
+	PrepareCallHierarchy(context.Context, *CallHierarchyPrepareParams) ([]CallHierarchyItem, error)              // textDocument/prepareCallHierarchy
+	PrepareRename(context.Context, *PrepareRenameParams) (*PrepareRenameResult, error)                           // textDocument/prepareRename
+	PrepareTypeHierarchy(context.Context, *TypeHierarchyPrepareParams) ([]TypeHierarchyItem, error)              // textDocument/prepareTypeHierarchy
+	RangeFormatting(context.Context, *DocumentRangeFormattingParams) ([]TextEdit, error)                         // textDocument/rangeFormatting
+	RangesFormatting(context.Context, *DocumentRangesFormattingParams) ([]TextEdit, error)                       // textDocument/rangesFormatting
+	References(context.Context, *ReferenceParams) ([]Location, error)                                            // textDocument/references
+	Rename(context.Context, *RenameParams) (*WorkspaceEdit, error)                                               // textDocument/rename
+	SelectionRange(context.Context, *SelectionRangeParams) ([]SelectionRange, error)                             // textDocument/selectionRange
+	SemanticTokensFull(context.Context, *SemanticTokensParams) (*SemanticTokens, error)                          // textDocument/semanticTokens/full
+	SemanticTokensFullDelta(context.Context, *SemanticTokensDeltaParams) (interface{}, error)                    // textDocument/semanticTokens/full/delta
+	SemanticTokensRange(context.Context, *SemanticTokensRangeParams) (*SemanticTokens, error)                    // textDocument/semanticTokens/range
+	SignatureHelp(context.Context, *SignatureHelpParams) (*SignatureHelp, error)                                 // textDocument/signatureHelp
+	TypeDefinition(context.Context, *TypeDefinitionParams) ([]Location, error)                                   // textDocument/typeDefinition
+	WillSave(context.Context, *WillSaveTextDocumentParams) error                                                 // textDocument/willSave
+	WillSaveWaitUntil(context.Context, *WillSaveTextDocumentParams) ([]TextEdit, error)                          // textDocument/willSaveWaitUntil
+	Subtypes(context.Context, *TypeHierarchySubtypesParams) ([]TypeHierarchyItem, error)                         // typeHierarchy/subtypes
+	Supertypes(context.Context, *TypeHierarchySupertypesParams) ([]TypeHierarchyItem, error)                     // typeHierarchy/supertypes
+	WorkDoneProgressCancel(context.Context, *WorkDoneProgressCancelParams) error                                 // window/workDoneProgress/cancel
+	DiagnosticWorkspace(context.Context, *WorkspaceDiagnosticParams) (*WorkspaceDiagnosticReport, error)         // workspace/diagnostic
+	DidChangeConfiguration(context.Context, *DidChangeConfigurationParams) error                                 // workspace/didChangeConfiguration
+	DidChangeWatchedFiles(context.Context, *DidChangeWatchedFilesParams) error                                   // workspace/didChangeWatchedFiles
+	DidChangeWorkspaceFolders(context.Context, *DidChangeWorkspaceFoldersParams) error                           // workspace/didChangeWorkspaceFolders
+	DidCreateFiles(context.Context, *CreateFilesParams) error                                                    // workspace/didCreateFiles
+	DidDeleteFiles(context.Context, *DeleteFilesParams) error                                                    // workspace/didDeleteFiles
+	DidRenameFiles(context.Context, *RenameFilesParams) error                                                    // workspace/didRenameFiles
+	ExecuteCommand(context.Context, *ExecuteCommandParams) (interface{}, error)                                  // workspace/executeCommand
+	Symbol(context.Context, *WorkspaceSymbolParams) ([]SymbolInformation, error)                                 // workspace/symbol
+	WillCreateFiles(context.Context, *CreateFilesParams) (*WorkspaceEdit, error)                                 // workspace/willCreateFiles
+	WillDeleteFiles(context.Context, *DeleteFilesParams) (*WorkspaceEdit, error)                                 // workspace/willDeleteFiles
+	WillRenameFiles(context.Context, *RenameFilesParams) (*WorkspaceEdit, error)                                 // workspace/willRenameFiles
+	ResolveWorkspaceSymbol(context.Context, *WorkspaceSymbol) (*WorkspaceSymbol, error)                          // workspaceSymbol/resolve
+
 }
 
 func ServerDispatch(ctx context.Context, server Server, conn *jsonrpc2.Conn, r *jsonrpc2.Request) (bool, error) {
@@ -101,6 +103,7 @@ func ServerDispatch(ctx context.Context, server Server, conn *jsonrpc2.Conn, r *
 		}
 		err := server.Progress(ctx, &params)
 		return true, reply(ctx, conn, r, nil, err)
+
 	case "$/setTrace":
 		var params SetTraceParams
 		if err := json.Unmarshal(*r.Params, &params); err != nil {
@@ -108,6 +111,7 @@ func ServerDispatch(ctx context.Context, server Server, conn *jsonrpc2.Conn, r *
 		}
 		err := server.SetTrace(ctx, &params)
 		return true, reply(ctx, conn, r, nil, err)
+
 	case "callHierarchy/incomingCalls":
 		var params CallHierarchyIncomingCallsParams
 		if err := json.Unmarshal(*r.Params, &params); err != nil {
@@ -118,6 +122,7 @@ func ServerDispatch(ctx context.Context, server Server, conn *jsonrpc2.Conn, r *
 			return true, reply(ctx, conn, r, nil, err)
 		}
 		return true, reply(ctx, conn, r, resp, nil)
+
 	case "callHierarchy/outgoingCalls":
 		var params CallHierarchyOutgoingCallsParams
 		if err := json.Unmarshal(*r.Params, &params); err != nil {
@@ -128,6 +133,7 @@ func ServerDispatch(ctx context.Context, server Server, conn *jsonrpc2.Conn, r *
 			return true, reply(ctx, conn, r, nil, err)
 		}
 		return true, reply(ctx, conn, r, resp, nil)
+
 	case "codeAction/resolve":
 		var params CodeAction
 		if err := json.Unmarshal(*r.Params, &params); err != nil {
@@ -138,6 +144,7 @@ func ServerDispatch(ctx context.Context, server Server, conn *jsonrpc2.Conn, r *
 			return true, reply(ctx, conn, r, nil, err)
 		}
 		return true, reply(ctx, conn, r, resp, nil)
+
 	case "codeLens/resolve":
 		var params CodeLens
 		if err := json.Unmarshal(*r.Params, &params); err != nil {
@@ -148,6 +155,7 @@ func ServerDispatch(ctx context.Context, server Server, conn *jsonrpc2.Conn, r *
 			return true, reply(ctx, conn, r, nil, err)
 		}
 		return true, reply(ctx, conn, r, resp, nil)
+
 	case "completionItem/resolve":
 		var params CompletionItem
 		if err := json.Unmarshal(*r.Params, &params); err != nil {
@@ -158,6 +166,7 @@ func ServerDispatch(ctx context.Context, server Server, conn *jsonrpc2.Conn, r *
 			return true, reply(ctx, conn, r, nil, err)
 		}
 		return true, reply(ctx, conn, r, resp, nil)
+
 	case "documentLink/resolve":
 		var params DocumentLink
 		if err := json.Unmarshal(*r.Params, &params); err != nil {
@@ -168,9 +177,11 @@ func ServerDispatch(ctx context.Context, server Server, conn *jsonrpc2.Conn, r *
 			return true, reply(ctx, conn, r, nil, err)
 		}
 		return true, reply(ctx, conn, r, resp, nil)
+
 	case "exit":
 		err := server.Exit(ctx)
 		return true, reply(ctx, conn, r, nil, err)
+
 	case "initialize":
 		var params ParamInitialize
 		if err := json.Unmarshal(*r.Params, &params); err != nil {
@@ -181,6 +192,7 @@ func ServerDispatch(ctx context.Context, server Server, conn *jsonrpc2.Conn, r *
 			return true, reply(ctx, conn, r, nil, err)
 		}
 		return true, reply(ctx, conn, r, resp, nil)
+
 	case "initialized":
 		var params InitializedParams
 		if err := json.Unmarshal(*r.Params, &params); err != nil {
@@ -188,6 +200,7 @@ func ServerDispatch(ctx context.Context, server Server, conn *jsonrpc2.Conn, r *
 		}
 		err := server.Initialized(ctx, &params)
 		return true, reply(ctx, conn, r, nil, err)
+
 	case "inlayHint/resolve":
 		var params InlayHint
 		if err := json.Unmarshal(*r.Params, &params); err != nil {
@@ -198,6 +211,7 @@ func ServerDispatch(ctx context.Context, server Server, conn *jsonrpc2.Conn, r *
 			return true, reply(ctx, conn, r, nil, err)
 		}
 		return true, reply(ctx, conn, r, resp, nil)
+
 	case "notebookDocument/didChange":
 		var params DidChangeNotebookDocumentParams
 		if err := json.Unmarshal(*r.Params, &params); err != nil {
@@ -205,6 +219,7 @@ func ServerDispatch(ctx context.Context, server Server, conn *jsonrpc2.Conn, r *
 		}
 		err := server.DidChangeNotebookDocument(ctx, &params)
 		return true, reply(ctx, conn, r, nil, err)
+
 	case "notebookDocument/didClose":
 		var params DidCloseNotebookDocumentParams
 		if err := json.Unmarshal(*r.Params, &params); err != nil {
@@ -212,6 +227,7 @@ func ServerDispatch(ctx context.Context, server Server, conn *jsonrpc2.Conn, r *
 		}
 		err := server.DidCloseNotebookDocument(ctx, &params)
 		return true, reply(ctx, conn, r, nil, err)
+
 	case "notebookDocument/didOpen":
 		var params DidOpenNotebookDocumentParams
 		if err := json.Unmarshal(*r.Params, &params); err != nil {
@@ -219,6 +235,7 @@ func ServerDispatch(ctx context.Context, server Server, conn *jsonrpc2.Conn, r *
 		}
 		err := server.DidOpenNotebookDocument(ctx, &params)
 		return true, reply(ctx, conn, r, nil, err)
+
 	case "notebookDocument/didSave":
 		var params DidSaveNotebookDocumentParams
 		if err := json.Unmarshal(*r.Params, &params); err != nil {
@@ -226,9 +243,11 @@ func ServerDispatch(ctx context.Context, server Server, conn *jsonrpc2.Conn, r *
 		}
 		err := server.DidSaveNotebookDocument(ctx, &params)
 		return true, reply(ctx, conn, r, nil, err)
+
 	case "shutdown":
 		err := server.Shutdown(ctx)
 		return true, reply(ctx, conn, r, nil, err)
+
 	case "textDocument/codeAction":
 		var params CodeActionParams
 		if err := json.Unmarshal(*r.Params, &params); err != nil {
@@ -239,6 +258,7 @@ func ServerDispatch(ctx context.Context, server Server, conn *jsonrpc2.Conn, r *
 			return true, reply(ctx, conn, r, nil, err)
 		}
 		return true, reply(ctx, conn, r, resp, nil)
+
 	case "textDocument/codeLens":
 		var params CodeLensParams
 		if err := json.Unmarshal(*r.Params, &params); err != nil {
@@ -249,6 +269,7 @@ func ServerDispatch(ctx context.Context, server Server, conn *jsonrpc2.Conn, r *
 			return true, reply(ctx, conn, r, nil, err)
 		}
 		return true, reply(ctx, conn, r, resp, nil)
+
 	case "textDocument/colorPresentation":
 		var params ColorPresentationParams
 		if err := json.Unmarshal(*r.Params, &params); err != nil {
@@ -259,6 +280,7 @@ func ServerDispatch(ctx context.Context, server Server, conn *jsonrpc2.Conn, r *
 			return true, reply(ctx, conn, r, nil, err)
 		}
 		return true, reply(ctx, conn, r, resp, nil)
+
 	case "textDocument/completion":
 		var params CompletionParams
 		if err := json.Unmarshal(*r.Params, &params); err != nil {
@@ -269,6 +291,7 @@ func ServerDispatch(ctx context.Context, server Server, conn *jsonrpc2.Conn, r *
 			return true, reply(ctx, conn, r, nil, err)
 		}
 		return true, reply(ctx, conn, r, resp, nil)
+
 	case "textDocument/declaration":
 		var params DeclarationParams
 		if err := json.Unmarshal(*r.Params, &params); err != nil {
@@ -279,6 +302,7 @@ func ServerDispatch(ctx context.Context, server Server, conn *jsonrpc2.Conn, r *
 			return true, reply(ctx, conn, r, nil, err)
 		}
 		return true, reply(ctx, conn, r, resp, nil)
+
 	case "textDocument/definition":
 		var params DefinitionParams
 		if err := json.Unmarshal(*r.Params, &params); err != nil {
@@ -289,6 +313,7 @@ func ServerDispatch(ctx context.Context, server Server, conn *jsonrpc2.Conn, r *
 			return true, reply(ctx, conn, r, nil, err)
 		}
 		return true, reply(ctx, conn, r, resp, nil)
+
 	case "textDocument/diagnostic":
 		var params string
 		if err := json.Unmarshal(*r.Params, &params); err != nil {
@@ -299,6 +324,7 @@ func ServerDispatch(ctx context.Context, server Server, conn *jsonrpc2.Conn, r *
 			return true, reply(ctx, conn, r, nil, err)
 		}
 		return true, reply(ctx, conn, r, resp, nil)
+
 	case "textDocument/didChange":
 		var params DidChangeTextDocumentParams
 		if err := json.Unmarshal(*r.Params, &params); err != nil {
@@ -306,6 +332,7 @@ func ServerDispatch(ctx context.Context, server Server, conn *jsonrpc2.Conn, r *
 		}
 		err := server.DidChange(ctx, &params)
 		return true, reply(ctx, conn, r, nil, err)
+
 	case "textDocument/didClose":
 		var params DidCloseTextDocumentParams
 		if err := json.Unmarshal(*r.Params, &params); err != nil {
@@ -313,6 +340,7 @@ func ServerDispatch(ctx context.Context, server Server, conn *jsonrpc2.Conn, r *
 		}
 		err := server.DidClose(ctx, &params)
 		return true, reply(ctx, conn, r, nil, err)
+
 	case "textDocument/didOpen":
 		var params DidOpenTextDocumentParams
 		if err := json.Unmarshal(*r.Params, &params); err != nil {
@@ -320,6 +348,7 @@ func ServerDispatch(ctx context.Context, server Server, conn *jsonrpc2.Conn, r *
 		}
 		err := server.DidOpen(ctx, &params)
 		return true, reply(ctx, conn, r, nil, err)
+
 	case "textDocument/didSave":
 		var params DidSaveTextDocumentParams
 		if err := json.Unmarshal(*r.Params, &params); err != nil {
@@ -327,6 +356,7 @@ func ServerDispatch(ctx context.Context, server Server, conn *jsonrpc2.Conn, r *
 		}
 		err := server.DidSave(ctx, &params)
 		return true, reply(ctx, conn, r, nil, err)
+
 	case "textDocument/documentColor":
 		var params DocumentColorParams
 		if err := json.Unmarshal(*r.Params, &params); err != nil {
@@ -337,6 +367,7 @@ func ServerDispatch(ctx context.Context, server Server, conn *jsonrpc2.Conn, r *
 			return true, reply(ctx, conn, r, nil, err)
 		}
 		return true, reply(ctx, conn, r, resp, nil)
+
 	case "textDocument/documentHighlight":
 		var params DocumentHighlightParams
 		if err := json.Unmarshal(*r.Params, &params); err != nil {
@@ -347,6 +378,7 @@ func ServerDispatch(ctx context.Context, server Server, conn *jsonrpc2.Conn, r *
 			return true, reply(ctx, conn, r, nil, err)
 		}
 		return true, reply(ctx, conn, r, resp, nil)
+
 	case "textDocument/documentLink":
 		var params DocumentLinkParams
 		if err := json.Unmarshal(*r.Params, &params); err != nil {
@@ -357,6 +389,7 @@ func ServerDispatch(ctx context.Context, server Server, conn *jsonrpc2.Conn, r *
 			return true, reply(ctx, conn, r, nil, err)
 		}
 		return true, reply(ctx, conn, r, resp, nil)
+
 	case "textDocument/documentSymbol":
 		var params DocumentSymbolParams
 		if err := json.Unmarshal(*r.Params, &params); err != nil {
@@ -367,6 +400,7 @@ func ServerDispatch(ctx context.Context, server Server, conn *jsonrpc2.Conn, r *
 			return true, reply(ctx, conn, r, nil, err)
 		}
 		return true, reply(ctx, conn, r, resp, nil)
+
 	case "textDocument/foldingRange":
 		var params FoldingRangeParams
 		if err := json.Unmarshal(*r.Params, &params); err != nil {
@@ -377,6 +411,7 @@ func ServerDispatch(ctx context.Context, server Server, conn *jsonrpc2.Conn, r *
 			return true, reply(ctx, conn, r, nil, err)
 		}
 		return true, reply(ctx, conn, r, resp, nil)
+
 	case "textDocument/formatting":
 		var params DocumentFormattingParams
 		if err := json.Unmarshal(*r.Params, &params); err != nil {
@@ -387,6 +422,7 @@ func ServerDispatch(ctx context.Context, server Server, conn *jsonrpc2.Conn, r *
 			return true, reply(ctx, conn, r, nil, err)
 		}
 		return true, reply(ctx, conn, r, resp, nil)
+
 	case "textDocument/hover":
 		var params HoverParams
 		if err := json.Unmarshal(*r.Params, &params); err != nil {
@@ -397,6 +433,7 @@ func ServerDispatch(ctx context.Context, server Server, conn *jsonrpc2.Conn, r *
 			return true, reply(ctx, conn, r, nil, err)
 		}
 		return true, reply(ctx, conn, r, resp, nil)
+
 	case "textDocument/implementation":
 		var params ImplementationParams
 		if err := json.Unmarshal(*r.Params, &params); err != nil {
@@ -407,6 +444,7 @@ func ServerDispatch(ctx context.Context, server Server, conn *jsonrpc2.Conn, r *
 			return true, reply(ctx, conn, r, nil, err)
 		}
 		return true, reply(ctx, conn, r, resp, nil)
+
 	case "textDocument/inlayHint":
 		var params InlayHintParams
 		if err := json.Unmarshal(*r.Params, &params); err != nil {
@@ -417,6 +455,18 @@ func ServerDispatch(ctx context.Context, server Server, conn *jsonrpc2.Conn, r *
 			return true, reply(ctx, conn, r, nil, err)
 		}
 		return true, reply(ctx, conn, r, resp, nil)
+
+	case "textDocument/inlineCompletion":
+		var params InlineCompletionParams
+		if err := json.Unmarshal(*r.Params, &params); err != nil {
+			return true, sendParseError(ctx, conn, r, err)
+		}
+		resp, err := server.InlineCompletion(ctx, &params)
+		if err != nil {
+			return true, reply(ctx, conn, r, nil, err)
+		}
+		return true, reply(ctx, conn, r, resp, nil)
+
 	case "textDocument/inlineValue":
 		var params InlineValueParams
 		if err := json.Unmarshal(*r.Params, &params); err != nil {
@@ -427,6 +477,7 @@ func ServerDispatch(ctx context.Context, server Server, conn *jsonrpc2.Conn, r *
 			return true, reply(ctx, conn, r, nil, err)
 		}
 		return true, reply(ctx, conn, r, resp, nil)
+
 	case "textDocument/linkedEditingRange":
 		var params LinkedEditingRangeParams
 		if err := json.Unmarshal(*r.Params, &params); err != nil {
@@ -437,6 +488,7 @@ func ServerDispatch(ctx context.Context, server Server, conn *jsonrpc2.Conn, r *
 			return true, reply(ctx, conn, r, nil, err)
 		}
 		return true, reply(ctx, conn, r, resp, nil)
+
 	case "textDocument/moniker":
 		var params MonikerParams
 		if err := json.Unmarshal(*r.Params, &params); err != nil {
@@ -447,6 +499,7 @@ func ServerDispatch(ctx context.Context, server Server, conn *jsonrpc2.Conn, r *
 			return true, reply(ctx, conn, r, nil, err)
 		}
 		return true, reply(ctx, conn, r, resp, nil)
+
 	case "textDocument/onTypeFormatting":
 		var params DocumentOnTypeFormattingParams
 		if err := json.Unmarshal(*r.Params, &params); err != nil {
@@ -457,6 +510,7 @@ func ServerDispatch(ctx context.Context, server Server, conn *jsonrpc2.Conn, r *
 			return true, reply(ctx, conn, r, nil, err)
 		}
 		return true, reply(ctx, conn, r, resp, nil)
+
 	case "textDocument/prepareCallHierarchy":
 		var params CallHierarchyPrepareParams
 		if err := json.Unmarshal(*r.Params, &params); err != nil {
@@ -467,6 +521,7 @@ func ServerDispatch(ctx context.Context, server Server, conn *jsonrpc2.Conn, r *
 			return true, reply(ctx, conn, r, nil, err)
 		}
 		return true, reply(ctx, conn, r, resp, nil)
+
 	case "textDocument/prepareRename":
 		var params PrepareRenameParams
 		if err := json.Unmarshal(*r.Params, &params); err != nil {
@@ -477,6 +532,7 @@ func ServerDispatch(ctx context.Context, server Server, conn *jsonrpc2.Conn, r *
 			return true, reply(ctx, conn, r, nil, err)
 		}
 		return true, reply(ctx, conn, r, resp, nil)
+
 	case "textDocument/prepareTypeHierarchy":
 		var params TypeHierarchyPrepareParams
 		if err := json.Unmarshal(*r.Params, &params); err != nil {
@@ -487,6 +543,7 @@ func ServerDispatch(ctx context.Context, server Server, conn *jsonrpc2.Conn, r *
 			return true, reply(ctx, conn, r, nil, err)
 		}
 		return true, reply(ctx, conn, r, resp, nil)
+
 	case "textDocument/rangeFormatting":
 		var params DocumentRangeFormattingParams
 		if err := json.Unmarshal(*r.Params, &params); err != nil {
@@ -497,6 +554,18 @@ func ServerDispatch(ctx context.Context, server Server, conn *jsonrpc2.Conn, r *
 			return true, reply(ctx, conn, r, nil, err)
 		}
 		return true, reply(ctx, conn, r, resp, nil)
+
+	case "textDocument/rangesFormatting":
+		var params DocumentRangesFormattingParams
+		if err := json.Unmarshal(*r.Params, &params); err != nil {
+			return true, sendParseError(ctx, conn, r, err)
+		}
+		resp, err := server.RangesFormatting(ctx, &params)
+		if err != nil {
+			return true, reply(ctx, conn, r, nil, err)
+		}
+		return true, reply(ctx, conn, r, resp, nil)
+
 	case "textDocument/references":
 		var params ReferenceParams
 		if err := json.Unmarshal(*r.Params, &params); err != nil {
@@ -507,6 +576,7 @@ func ServerDispatch(ctx context.Context, server Server, conn *jsonrpc2.Conn, r *
 			return true, reply(ctx, conn, r, nil, err)
 		}
 		return true, reply(ctx, conn, r, resp, nil)
+
 	case "textDocument/rename":
 		var params RenameParams
 		if err := json.Unmarshal(*r.Params, &params); err != nil {
@@ -517,6 +587,7 @@ func ServerDispatch(ctx context.Context, server Server, conn *jsonrpc2.Conn, r *
 			return true, reply(ctx, conn, r, nil, err)
 		}
 		return true, reply(ctx, conn, r, resp, nil)
+
 	case "textDocument/selectionRange":
 		var params SelectionRangeParams
 		if err := json.Unmarshal(*r.Params, &params); err != nil {
@@ -527,6 +598,7 @@ func ServerDispatch(ctx context.Context, server Server, conn *jsonrpc2.Conn, r *
 			return true, reply(ctx, conn, r, nil, err)
 		}
 		return true, reply(ctx, conn, r, resp, nil)
+
 	case "textDocument/semanticTokens/full":
 		var params SemanticTokensParams
 		if err := json.Unmarshal(*r.Params, &params); err != nil {
@@ -537,6 +609,7 @@ func ServerDispatch(ctx context.Context, server Server, conn *jsonrpc2.Conn, r *
 			return true, reply(ctx, conn, r, nil, err)
 		}
 		return true, reply(ctx, conn, r, resp, nil)
+
 	case "textDocument/semanticTokens/full/delta":
 		var params SemanticTokensDeltaParams
 		if err := json.Unmarshal(*r.Params, &params); err != nil {
@@ -547,6 +620,7 @@ func ServerDispatch(ctx context.Context, server Server, conn *jsonrpc2.Conn, r *
 			return true, reply(ctx, conn, r, nil, err)
 		}
 		return true, reply(ctx, conn, r, resp, nil)
+
 	case "textDocument/semanticTokens/range":
 		var params SemanticTokensRangeParams
 		if err := json.Unmarshal(*r.Params, &params); err != nil {
@@ -557,6 +631,7 @@ func ServerDispatch(ctx context.Context, server Server, conn *jsonrpc2.Conn, r *
 			return true, reply(ctx, conn, r, nil, err)
 		}
 		return true, reply(ctx, conn, r, resp, nil)
+
 	case "textDocument/signatureHelp":
 		var params SignatureHelpParams
 		if err := json.Unmarshal(*r.Params, &params); err != nil {
@@ -567,6 +642,7 @@ func ServerDispatch(ctx context.Context, server Server, conn *jsonrpc2.Conn, r *
 			return true, reply(ctx, conn, r, nil, err)
 		}
 		return true, reply(ctx, conn, r, resp, nil)
+
 	case "textDocument/typeDefinition":
 		var params TypeDefinitionParams
 		if err := json.Unmarshal(*r.Params, &params); err != nil {
@@ -577,6 +653,7 @@ func ServerDispatch(ctx context.Context, server Server, conn *jsonrpc2.Conn, r *
 			return true, reply(ctx, conn, r, nil, err)
 		}
 		return true, reply(ctx, conn, r, resp, nil)
+
 	case "textDocument/willSave":
 		var params WillSaveTextDocumentParams
 		if err := json.Unmarshal(*r.Params, &params); err != nil {
@@ -584,6 +661,7 @@ func ServerDispatch(ctx context.Context, server Server, conn *jsonrpc2.Conn, r *
 		}
 		err := server.WillSave(ctx, &params)
 		return true, reply(ctx, conn, r, nil, err)
+
 	case "textDocument/willSaveWaitUntil":
 		var params WillSaveTextDocumentParams
 		if err := json.Unmarshal(*r.Params, &params); err != nil {
@@ -594,6 +672,7 @@ func ServerDispatch(ctx context.Context, server Server, conn *jsonrpc2.Conn, r *
 			return true, reply(ctx, conn, r, nil, err)
 		}
 		return true, reply(ctx, conn, r, resp, nil)
+
 	case "typeHierarchy/subtypes":
 		var params TypeHierarchySubtypesParams
 		if err := json.Unmarshal(*r.Params, &params); err != nil {
@@ -604,6 +683,7 @@ func ServerDispatch(ctx context.Context, server Server, conn *jsonrpc2.Conn, r *
 			return true, reply(ctx, conn, r, nil, err)
 		}
 		return true, reply(ctx, conn, r, resp, nil)
+
 	case "typeHierarchy/supertypes":
 		var params TypeHierarchySupertypesParams
 		if err := json.Unmarshal(*r.Params, &params); err != nil {
@@ -614,6 +694,7 @@ func ServerDispatch(ctx context.Context, server Server, conn *jsonrpc2.Conn, r *
 			return true, reply(ctx, conn, r, nil, err)
 		}
 		return true, reply(ctx, conn, r, resp, nil)
+
 	case "window/workDoneProgress/cancel":
 		var params WorkDoneProgressCancelParams
 		if err := json.Unmarshal(*r.Params, &params); err != nil {
@@ -621,6 +702,7 @@ func ServerDispatch(ctx context.Context, server Server, conn *jsonrpc2.Conn, r *
 		}
 		err := server.WorkDoneProgressCancel(ctx, &params)
 		return true, reply(ctx, conn, r, nil, err)
+
 	case "workspace/diagnostic":
 		var params WorkspaceDiagnosticParams
 		if err := json.Unmarshal(*r.Params, &params); err != nil {
@@ -631,6 +713,7 @@ func ServerDispatch(ctx context.Context, server Server, conn *jsonrpc2.Conn, r *
 			return true, reply(ctx, conn, r, nil, err)
 		}
 		return true, reply(ctx, conn, r, resp, nil)
+
 	case "workspace/didChangeConfiguration":
 		var params DidChangeConfigurationParams
 		if err := json.Unmarshal(*r.Params, &params); err != nil {
@@ -638,6 +721,7 @@ func ServerDispatch(ctx context.Context, server Server, conn *jsonrpc2.Conn, r *
 		}
 		err := server.DidChangeConfiguration(ctx, &params)
 		return true, reply(ctx, conn, r, nil, err)
+
 	case "workspace/didChangeWatchedFiles":
 		var params DidChangeWatchedFilesParams
 		if err := json.Unmarshal(*r.Params, &params); err != nil {
@@ -645,6 +729,7 @@ func ServerDispatch(ctx context.Context, server Server, conn *jsonrpc2.Conn, r *
 		}
 		err := server.DidChangeWatchedFiles(ctx, &params)
 		return true, reply(ctx, conn, r, nil, err)
+
 	case "workspace/didChangeWorkspaceFolders":
 		var params DidChangeWorkspaceFoldersParams
 		if err := json.Unmarshal(*r.Params, &params); err != nil {
@@ -652,6 +737,7 @@ func ServerDispatch(ctx context.Context, server Server, conn *jsonrpc2.Conn, r *
 		}
 		err := server.DidChangeWorkspaceFolders(ctx, &params)
 		return true, reply(ctx, conn, r, nil, err)
+
 	case "workspace/didCreateFiles":
 		var params CreateFilesParams
 		if err := json.Unmarshal(*r.Params, &params); err != nil {
@@ -659,6 +745,7 @@ func ServerDispatch(ctx context.Context, server Server, conn *jsonrpc2.Conn, r *
 		}
 		err := server.DidCreateFiles(ctx, &params)
 		return true, reply(ctx, conn, r, nil, err)
+
 	case "workspace/didDeleteFiles":
 		var params DeleteFilesParams
 		if err := json.Unmarshal(*r.Params, &params); err != nil {
@@ -666,6 +753,7 @@ func ServerDispatch(ctx context.Context, server Server, conn *jsonrpc2.Conn, r *
 		}
 		err := server.DidDeleteFiles(ctx, &params)
 		return true, reply(ctx, conn, r, nil, err)
+
 	case "workspace/didRenameFiles":
 		var params RenameFilesParams
 		if err := json.Unmarshal(*r.Params, &params); err != nil {
@@ -673,6 +761,7 @@ func ServerDispatch(ctx context.Context, server Server, conn *jsonrpc2.Conn, r *
 		}
 		err := server.DidRenameFiles(ctx, &params)
 		return true, reply(ctx, conn, r, nil, err)
+
 	case "workspace/executeCommand":
 		var params ExecuteCommandParams
 		if err := json.Unmarshal(*r.Params, &params); err != nil {
@@ -683,6 +772,7 @@ func ServerDispatch(ctx context.Context, server Server, conn *jsonrpc2.Conn, r *
 			return true, reply(ctx, conn, r, nil, err)
 		}
 		return true, reply(ctx, conn, r, resp, nil)
+
 	case "workspace/symbol":
 		var params WorkspaceSymbolParams
 		if err := json.Unmarshal(*r.Params, &params); err != nil {
@@ -693,8 +783,9 @@ func ServerDispatch(ctx context.Context, server Server, conn *jsonrpc2.Conn, r *
 			return true, reply(ctx, conn, r, nil, err)
 		}
 		return true, reply(ctx, conn, r, resp, nil)
+
 	case "workspace/willCreateFiles":
-		var params CreateFilesParams
+	var params CreateFilesParams
 		if err := json.Unmarshal(*r.Params, &params); err != nil {
 			return true, sendParseError(ctx, conn, r, err)
 		}
@@ -703,6 +794,7 @@ func ServerDispatch(ctx context.Context, server Server, conn *jsonrpc2.Conn, r *
 			return true, reply(ctx, conn, r, nil, err)
 		}
 		return true, reply(ctx, conn, r, resp, nil)
+
 	case "workspace/willDeleteFiles":
 		var params DeleteFilesParams
 		if err := json.Unmarshal(*r.Params, &params); err != nil {
@@ -713,6 +805,7 @@ func ServerDispatch(ctx context.Context, server Server, conn *jsonrpc2.Conn, r *
 			return true, reply(ctx, conn, r, nil, err)
 		}
 		return true, reply(ctx, conn, r, resp, nil)
+
 	case "workspace/willRenameFiles":
 		var params RenameFilesParams
 		if err := json.Unmarshal(*r.Params, &params); err != nil {
@@ -723,6 +816,7 @@ func ServerDispatch(ctx context.Context, server Server, conn *jsonrpc2.Conn, r *
 			return true, reply(ctx, conn, r, nil, err)
 		}
 		return true, reply(ctx, conn, r, resp, nil)
+
 	case "workspaceSymbol/resolve":
 		var params WorkspaceSymbol
 		if err := json.Unmarshal(*r.Params, &params); err != nil {
@@ -733,6 +827,7 @@ func ServerDispatch(ctx context.Context, server Server, conn *jsonrpc2.Conn, r *
 			return true, reply(ctx, conn, r, nil, err)
 		}
 		return true, reply(ctx, conn, r, resp, nil)
+
 	default:
 		return false, nil
 	}
@@ -842,8 +937,8 @@ func (s *serverDispatcher) ColorPresentation(ctx context.Context, params *ColorP
 	}
 	return result, nil
 }
-func (s *serverDispatcher) Completion(ctx context.Context, params *CompletionParams) (*CompletionList, error) {
-	var result *CompletionList
+func (s *serverDispatcher) Completion(ctx context.Context, params *CompletionParams) (*Or_Result_textDocument_completion, error) {
+	var result *Or_Result_textDocument_completion
 	if err := s.sender.Call(ctx, "textDocument/completion", params, &result); err != nil {
 		return nil, err
 	}
@@ -856,8 +951,8 @@ func (s *serverDispatcher) Declaration(ctx context.Context, params *DeclarationP
 	}
 	return result, nil
 }
-func (s *serverDispatcher) Definition(ctx context.Context, params *DefinitionParams) ([]Location, error) {
-	var result []Location
+func (s *serverDispatcher) Definition(ctx context.Context, params *DefinitionParams) (*Or_Result_textDocument_definition, error) {
+	var result *Or_Result_textDocument_definition
 	if err := s.sender.Call(ctx, "textDocument/definition", params, &result); err != nil {
 		return nil, err
 	}
@@ -945,6 +1040,13 @@ func (s *serverDispatcher) InlayHint(ctx context.Context, params *InlayHintParam
 	}
 	return result, nil
 }
+func (s *serverDispatcher) InlineCompletion(ctx context.Context, params *InlineCompletionParams) (*Or_Result_textDocument_inlineCompletion, error) {
+	var result *Or_Result_textDocument_inlineCompletion
+	if err := s.sender.Call(ctx, "textDocument/inlineCompletion", params, &result); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
 func (s *serverDispatcher) InlineValue(ctx context.Context, params *InlineValueParams) ([]InlineValue, error) {
 	var result []InlineValue
 	if err := s.sender.Call(ctx, "textDocument/inlineValue", params, &result); err != nil {
@@ -980,8 +1082,8 @@ func (s *serverDispatcher) PrepareCallHierarchy(ctx context.Context, params *Cal
 	}
 	return result, nil
 }
-func (s *serverDispatcher) PrepareRename(ctx context.Context, params *PrepareRenameParams) (*PrepareRename2Gn, error) {
-	var result *PrepareRename2Gn
+func (s *serverDispatcher) PrepareRename(ctx context.Context, params *PrepareRenameParams) (*PrepareRenameResult, error) {
+	var result *PrepareRenameResult
 	if err := s.sender.Call(ctx, "textDocument/prepareRename", params, &result); err != nil {
 		return nil, err
 	}
@@ -997,6 +1099,13 @@ func (s *serverDispatcher) PrepareTypeHierarchy(ctx context.Context, params *Typ
 func (s *serverDispatcher) RangeFormatting(ctx context.Context, params *DocumentRangeFormattingParams) ([]TextEdit, error) {
 	var result []TextEdit
 	if err := s.sender.Call(ctx, "textDocument/rangeFormatting", params, &result); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+func (s *serverDispatcher) RangesFormatting(ctx context.Context, params *DocumentRangesFormattingParams) ([]TextEdit, error) {
+	var result []TextEdit
+	if err := s.sender.Call(ctx, "textDocument/rangesFormatting", params, &result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -1147,13 +1256,6 @@ func (s *serverDispatcher) WillRenameFiles(ctx context.Context, params *RenameFi
 func (s *serverDispatcher) ResolveWorkspaceSymbol(ctx context.Context, params *WorkspaceSymbol) (*WorkspaceSymbol, error) {
 	var result *WorkspaceSymbol
 	if err := s.sender.Call(ctx, "workspaceSymbol/resolve", params, &result); err != nil {
-		return nil, err
-	}
-	return result, nil
-}
-func (s *serverDispatcher) NonstandardRequest(ctx context.Context, method string, params interface{}) (interface{}, error) {
-	var result interface{}
-	if err := s.sender.Call(ctx, method, params, &result); err != nil {
 		return nil, err
 	}
 	return result, nil


### PR DESCRIPTION
Let Completion and Definition return the full sum types as defined in the LSP spec, instead of gopls specific types. This will accomodate a wider range of LSP-servers, in particular clojure-lsp (see [https://github.com/fhs/acme-lsp/issues/29](https://github.com/fhs/acme-lsp/issues/29)).

As we're at it, generate the protocol types from the most recent LSP spec.