### PR TITLE
Omit unset ranges for TextDocumentContentChangeEvent

### DIFF
--- a/lsp/protocol/generate/tables.go
+++ b/lsp/protocol/generate/tables.go
@@ -46,7 +46,7 @@ var goplsStar = map[prop]int{
 	{"Lit_SemanticTokensClientCapabilities_requests_full_Item1", "delta"}: nothing, // A.B.C.D
 	{"Lit_SemanticTokensOptions_full_Item1", "delta"}:                     nothing, // A.B.C.
 
-	{"Lit_TextDocumentContentChangeEvent_Item0", "range"}: wantStar, // == nil test
+	{"Lit_TextDocumentContentChangeEvent_Item0", "range"}: wantOptStar, // == nil test, TS LSP checks for undefined instead of null.
 
 	{"TextDocumentClientCapabilities", "codeAction"}:          wantOpt, // A.B.C.D
 	{"TextDocumentClientCapabilities", "completion"}:          wantOpt, // A.B.C.D

--- a/lsp/protocol/tsprotocol.go
+++ b/lsp/protocol/tsprotocol.go
@@ -2443,7 +2443,7 @@ type Msg_PrepareRename2Gn struct { // line 13911
 // created for Literal (Lit_TextDocumentContentChangeEvent_Item0)
 type Msg_TextDocumentContentChangeEvent struct { // line 14008
 	// The range of the document that changed.
-	Range *Range `json:"range"`
+	Range *Range `json:"range,omitempty"`
 	// The optional length of the range that got replaced.
 	//
 	// @deprecated use range instead.


### PR DESCRIPTION
The Typescript language server [checks ranges only for equality to `undefined`](https://github.com/microsoft/vscode-languageserver-node/blob/1ce790dd341a38da1fbf902cddc16ce456149de0/protocol/src/common/protocol.ts#L1915) to determine if a change is incremental.

This means that unset ranges need to be omitted completely from the generated messages instead of encoding them as `null` to avoid the Typescript LSP (and possibly others reusing the VSCode LSP code) tripping over range elements being unset, and thus not updating its internal view of text documents when `acme-lsp` handles a Put.

Fixes https://github.com/9fans/acme-lsp/issues/75