### PR TITLE
Remove gopls specific protocol simplification for hover responses

### DIFF
--- a/lsp/protocol/generate/tables.go
+++ b/lsp/protocol/generate/tables.go
@@ -74,7 +74,6 @@ var renameProp = map[prop]string{
 
 	{"ExecuteCommandParams", "arguments"}: "[]json.RawMessage",
 	{"FoldingRange", "kind"}:              "string",
-	{"Hover", "contents"}:                 "MarkupContent",
 	{"InlayHint", "label"}:                "[]InlayHintLabelPart",
 
 	{"RelatedFullDocumentDiagnosticReport", "relatedDocuments"}:      "map[DocumentURI]interface{}",

--- a/lsp/protocol/tsprotocol.go
+++ b/lsp/protocol/tsprotocol.go
@@ -1817,7 +1817,7 @@ type GlobPattern = string // (alias) line 14127
 // The result of a hover request.
 type Hover struct { // line 4886
 	// The hover's content
-	Contents MarkupContent `json:"contents"`
+	Contents Or_Hover_contents `json:"contents"`
 	// An optional range inside the text document that is used to
 	// visualize the hover, e.g. by changing the background color.
 	Range Range `json:"range,omitempty"`


### PR DESCRIPTION
LSPs other than gopls (such as Dart LS) can use the deprecated `MarkedString` type for hover responses. Remove the gopls-specific simplification so that we can decode those as well.